### PR TITLE
Align RabbitMQ config, integrate queue settings, and add doc-manager/worker to docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,23 @@ FRONTEND_BASE_URL=<http://localhost:3000 or your live URL>
 # Rate limits
 REGISTER_RATE_LIMIT=5/minute
 LOGIN_RATE_LIMIT=5/minute
+
+# Doc Manager
+UPLOAD_DIR=./doc-manager/uploads
+STORAGE_BACKEND=local
+OCR_SERVICE_URL=http://localhost:8002/ocr
+
+# RabbitMQ
+RABBITMQ_HOST=localhost
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest
+RABBITMQ_QUEUE=ocr_tasks
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+RABBITMQ_URI=
+
+# Cloudflare R2 (optional)
+R2_ENDPOINT_URL=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A web-based tool to convert Arabic PDF files (with diacritical marks) into edita
 - Converts result to `.docx` format
 - Download Word doc from browser
 
+## 🚧 Current Development Status
+- File upload, listing, preview, and download are implemented via the Doc Manager service.
+- OCR processing and DOCX generation are not yet wired into the worker pipeline.
+
 ---
 
 ## 🏗️ Project Structure

--- a/doc-manager/app/core/config.py
+++ b/doc-manager/app/core/config.py
@@ -7,6 +7,9 @@ class Settings(BaseSettings):
     rabbitmq_port: int = Field(default=5672, env="RABBITMQ_PORT")
     rabbitmq_url: str | None = Field(default=None, env="RABBITMQ_URL")
     rabbitmq_queue: str = Field(default="ocr_tasks", env="RABBITMQ_QUEUE")
+    rabbitmq_user: str = Field(default="guest", env="RABBITMQ_USER")
+    rabbitmq_pass: str = Field(default="guest", env="RABBITMQ_PASS")
+    rabbitmq_uri: str | None = Field(default=None, env="RABBITMQ_URI")
 
     ocr_service_url: AnyUrl = Field(default="http://localhost:8001/ocr", env="OCR_SERVICE_URL")
     STORAGE_BACKEND: str

--- a/doc-manager/app/queue/task_queue.py
+++ b/doc-manager/app/queue/task_queue.py
@@ -3,15 +3,27 @@ import pika
 from app.core.config import settings
 
 def publish_task(message: dict):
-    connection = pika.BlockingConnection(pika.URLParameters(settings.RABBITMQ_URI))
+    rabbitmq_uri = settings.rabbitmq_uri or settings.rabbitmq_url
+    if rabbitmq_uri:
+        parameters = pika.URLParameters(rabbitmq_uri)
+    else:
+        parameters = pika.ConnectionParameters(
+            host=settings.rabbitmq_host,
+            port=settings.rabbitmq_port,
+            credentials=pika.PlainCredentials(
+                settings.rabbitmq_user,
+                settings.rabbitmq_pass,
+            ),
+        )
+    connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
 
     # Ensure queue exists
-    channel.queue_declare(queue=settings.RABBITMQ_QUEUE, durable=True)
+    channel.queue_declare(queue=settings.rabbitmq_queue, durable=True)
 
     channel.basic_publish(
         exchange="",
-        routing_key=settings.RABBITMQ_QUEUE,
+        routing_key=settings.rabbitmq_queue,
         body=json.dumps(message),
         properties=pika.BasicProperties(
             delivery_mode=2  # make message persistent

--- a/doc-manager/app/worker/consumer.py
+++ b/doc-manager/app/worker/consumer.py
@@ -17,19 +17,19 @@ def process_task(task):
 
 def consume():
     # Added credentials and port
-    credentials = pika.PlainCredentials(settings.RABBITMQ_USER, settings.RABBITMQ_PASS)
+    credentials = pika.PlainCredentials(settings.rabbitmq_user, settings.rabbitmq_pass)
     connection = pika.BlockingConnection(
         pika.ConnectionParameters(
-            host=settings.RABBITMQ_HOST,
-            port=settings.RABBITMQ_PORT,
+            host=settings.rabbitmq_host,
+            port=settings.rabbitmq_port,
             credentials=credentials
         )
     )
     channel = connection.channel()
 
     # Use config-based queue name
-    channel.queue_declare(queue=settings.RABBITMQ_QUEUE, durable=True)
-    logger.info(f"Waiting for messages in '{settings.RABBITMQ_QUEUE}' queue. To exit press CTRL+C")
+    channel.queue_declare(queue=settings.rabbitmq_queue, durable=True)
+    logger.info(f"Waiting for messages in '{settings.rabbitmq_queue}' queue. To exit press CTRL+C")
 
     def callback(ch, method, properties, body):
         try:
@@ -41,7 +41,7 @@ def consume():
             ch.basic_ack(delivery_tag=method.delivery_tag)
 
     channel.basic_qos(prefetch_count=1)
-    channel.basic_consume(queue=settings.RABBITMQ_QUEUE, on_message_callback=callback)
+    channel.basic_consume(queue=settings.rabbitmq_queue, on_message_callback=callback)
 
     try:
         channel.start_consuming()

--- a/doc-manager/app/worker/publisher.py
+++ b/doc-manager/app/worker/publisher.py
@@ -4,14 +4,14 @@ from app.core.config import settings
 
 def publish_task(task: dict):
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host=settings.RABBITMQ_HOST)
+        pika.ConnectionParameters(host=settings.rabbitmq_host)
     )
     channel = connection.channel()
 
-    channel.queue_declare(queue='doc_tasks', durable=True)
+    channel.queue_declare(queue=settings.rabbitmq_queue, durable=True)
     channel.basic_publish(
         exchange='',
-        routing_key='doc_tasks',
+        routing_key=settings.rabbitmq_queue,
         body=json.dumps(task),
         properties=pika.BasicProperties(delivery_mode=2),  # make message persistent
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,65 @@ services:
     networks:
       - backend
 
+  rabbitmq:
+    image: rabbitmq:3.12-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - backend
+
+  doc-manager:
+    build:
+      context: ./doc-manager
+      dockerfile: Dockerfile
+    image: doc-manager:dev
+    env_file:
+      - ./.env
+    environment:
+      UPLOAD_DIR: /app/uploads
+      STORAGE_BACKEND: local
+    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 8001
+    ports:
+      - "8001:8001"
+    depends_on:
+      - rabbitmq
+    volumes:
+      - ./doc-manager/app:/app/app
+      - ./doc-manager/uploads:/app/uploads
+    networks:
+      - backend
+
+  doc-worker:
+    image: doc-manager:dev
+    env_file:
+      - ./.env
+    environment:
+      UPLOAD_DIR: /app/uploads
+      STORAGE_BACKEND: local
+    command: python -m app.worker.consumer
+    depends_on:
+      - rabbitmq
+    volumes:
+      - ./doc-manager/app:/app/app
+    networks:
+      - backend
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_AUTH_API_URL: http://localhost:8000
+        VITE_DOC_API_URL: http://localhost:8001
+    ports:
+      - "8080:80"
+    depends_on:
+      - auth-service
+      - doc-manager
+    networks:
+      - backend
+
 networks:
   backend:
     driver: bridge


### PR DESCRIPTION
### Motivation
- Make RabbitMQ connection settings consistent and configurable across the doc-manager service, worker, and publisher so deployments can use either a full URI or host/port/credentials.
- Provide sane local development defaults and compose services so the doc-manager and worker can be run together with RabbitMQ and the frontend.
- Surface current pipeline status in the README to set expectations for contributors.

### Description
- Added `rabbitmq_user`, `rabbitmq_pass`, and `rabbitmq_uri` fields to `Settings` in `doc-manager/app/core/config.py` and kept existing host/port/url values for compatibility.
- Updated `doc-manager/app/queue/task_queue.py` to prefer `rabbitmq_uri`/`rabbitmq_url` (via `pika.URLParameters`) and fall back to `ConnectionParameters` with `PlainCredentials` using the new settings, and to use the configured queue name (`settings.rabbitmq_queue`).
- Updated `doc-manager/app/worker/consumer.py` and `doc-manager/app/worker/publisher.py` to use the new `rabbitmq_*` settings and the unified `rabbitmq_queue` name.
- Expanded `.env.example` with Doc Manager, OCR, RabbitMQ, and optional Cloudflare R2 environment variables, and extended `docker-compose.yml` with `rabbitmq`, `doc-manager`, `doc-worker`, and `frontend` services plus environment/volumes/ports for local development.
- Added a short note in `README.md` describing the current development status of the OCR pipeline.

### Testing
- No automated tests were executed for this change because it is configuration and wiring focused; manual/local startup is recommended to validate runtime integration (e.g., `docker-compose up --build`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69704dbefbd48333bc16f00c5cae1786)