### PR TITLE
chore: re-enable GHA build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
         with:
           context: ./auth-service
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=auth-service
+          cache-to: type=gha,mode=max,scope=auth-service
 
       - name: Build doc-manager
         uses: docker/build-push-action@v5
         with:
           context: ./doc-manager
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=doc-manager
+          cache-to: type=gha,mode=max,scope=doc-manager
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,8 @@ jobs:
           context: ./auth-service
           push: true
           platforms: linux/arm64
-          no-cache: true
+          cache-from: type=gha,scope=auth-service
+          cache-to: type=gha,mode=max,scope=auth-service
           tags: |
             ${{ env.IMAGE_PREFIX }}/auth-service:latest
             ${{ env.IMAGE_PREFIX }}/auth-service:${{ github.sha }}
@@ -42,7 +43,8 @@ jobs:
           context: ./doc-manager
           push: true
           platforms: linux/arm64
-          no-cache: true
+          cache-from: type=gha,scope=doc-manager
+          cache-to: type=gha,mode=max,scope=doc-manager
           tags: |
             ${{ env.IMAGE_PREFIX }}/doc-manager:latest
             ${{ env.IMAGE_PREFIX }}/doc-manager:${{ github.sha }}
@@ -53,7 +55,8 @@ jobs:
           context: ./frontend
           push: true
           platforms: linux/arm64
-          no-cache: true
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
           tags: |
             ${{ env.IMAGE_PREFIX }}/frontend:latest
             ${{ env.IMAGE_PREFIX }}/frontend:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Replaces `no-cache: true` (hotfix) with scoped GHA cache on all three Docker build steps in `deploy.yml`
- Adds matching scopes to `ci.yml` so CI and deploy share the same cache entries per service
- First deploy after merge will be a cold build (populates cache); subsequent deploys will be significantly faster

## Why it's safe now
The original `no-cache` was added because stale GHA cache had an old `doc-manager` image layer without `ENV PATH=/app/.venv/bin:$PATH`, causing `pika` import failures in the doc-worker. That Dockerfile fix is now committed and deployed — the cache will be built from the correct Dockerfile.

## Test plan
- [ ] CI `build` job passes on this PR
- [ ] After merge to `dev`, merge `dev` → `main` and confirm deploy completes without rollback
- [ ] Second deploy (any follow-up push) runs noticeably faster due to cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)