### PR TITLE
fix: deploy Modal OCR pipeline rewrite to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
         with:
           context: ./auth-service
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=auth-service
+          cache-to: type=gha,mode=max,scope=auth-service
 
       - name: Build doc-manager
         uses: docker/build-push-action@v5
         with:
           context: ./doc-manager
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=doc-manager
+          cache-to: type=gha,mode=max,scope=doc-manager
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,8 @@ jobs:
           context: ./auth-service
           push: true
           platforms: linux/arm64
-          no-cache: true
+          cache-from: type=gha,scope=auth-service
+          cache-to: type=gha,mode=max,scope=auth-service
           tags: |
             ${{ env.IMAGE_PREFIX }}/auth-service:latest
             ${{ env.IMAGE_PREFIX }}/auth-service:${{ github.sha }}
@@ -42,7 +43,8 @@ jobs:
           context: ./doc-manager
           push: true
           platforms: linux/arm64
-          no-cache: true
+          cache-from: type=gha,scope=doc-manager
+          cache-to: type=gha,mode=max,scope=doc-manager
           tags: |
             ${{ env.IMAGE_PREFIX }}/doc-manager:latest
             ${{ env.IMAGE_PREFIX }}/doc-manager:${{ github.sha }}
@@ -53,7 +55,8 @@ jobs:
           context: ./frontend
           push: true
           platforms: linux/arm64
-          no-cache: true
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
           tags: |
             ${{ env.IMAGE_PREFIX }}/frontend:latest
             ${{ env.IMAGE_PREFIX }}/frontend:${{ github.sha }}

--- a/ocr-worker/modal_app.py
+++ b/ocr-worker/modal_app.py
@@ -4,323 +4,193 @@ Textara OCR Pipeline — Modal GPU endpoint
 Receives a PDF as raw bytes, returns a DOCX as raw bytes.
 
 Pipeline per page:
-  1. pdf2image → PIL images at 300 DPI
-  2. Detectron2 layout model → bounding boxes (7 classes)
-  3. Crop each region, sort Arabic-order (RTL within row, top-to-bottom)
-  4. Qari OCR (Qwen2-VL 2B) on each cropped region
-  5. Assemble python-docx with proper RTL styles
+  1. PyMuPDF renders each page as a PIL image at 100 DPI
+  2. Full-page image sent to Qari OCR (Qwen2-VL 2B) in one shot
+  3. Assemble python-docx with RTL styles
+
+Model loading:
+  - bf16 Qwen2-VL-2B-Instruct base (SDPA attention)
+  - Qari LoRA applied then merged (removes adapter overhead)
+  - torch.compile(reduce-overhead) for faster repeated inference
 
 Deploy:  modal deploy ocr-worker/modal_app.py
-Call:    textara_ocr = modal.Function.lookup("textara-ocr", "process_pdf")
-         docx_bytes  = textara_ocr.remote(pdf_bytes)
+Call:    OCRPipeline = modal.Cls.from_name("textara-ocr", "OCRPipeline")
+         docx_bytes  = OCRPipeline().process_pdf.remote(pdf_bytes)
 """
 
 import io
-import os
-import tempfile
 
 import modal
 
 image = (
     modal.Image.debian_slim(python_version="3.11")
     .apt_install(
-        "poppler-utils",
-        "libgl1-mesa-glx",
-        "libglib2.0-0",
-        "wget",
-        "git",
+        "libmupdf-dev",
+        "mupdf-tools",
     )
     .pip_install(
         "numpy<2",
-        "torch==2.1.2",
-        "torchvision==0.16.2",
-        "transformers==4.49.0",
+        "torch==2.4.0",
+        "torchvision==0.19.0",
+        "transformers>=4.49.0",
         "qwen-vl-utils",
         "accelerate>=0.26.0",
-        "bitsandbytes",
-        "opencv-python-headless",
-        "fvcore",
-        "iopath",
-        "pdf2image",
+        "peft",
+        "pymupdf",
         "Pillow",
         "python-docx",
-        "boto3",
-    )
-    .run_commands(
-        "pip install 'detectron2 @ git+https://github.com/facebookresearch/detectron2.git'"
     )
 )
 
 app = modal.App("textara-ocr", image=image)
 
-LABEL_MAP = {
-    0: "page_number",
-    1: "section_header",
-    2: "paragraph",
-    3: "title",
-    4: "figure",
-    5: "footer",
-    6: "subtitle",
-}
+BASE_MODEL_ID = "Qwen/Qwen2-VL-2B-Instruct"
+LORA_MODEL_ID = "NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct"
 
-SKIP_LABELS = {"page_number", "footer", "figure"}
+DPI        = 100
+MAX_PIXELS = 1280 * 28 * 28   # ~1 M pixels — full A4 page fits without downscaling
 
-STYLE_MAP = {
-    "title": ("Heading 1", True),
-    "section_header": ("Heading 2", True),
-    "subtitle": ("Heading 3", False),
-    "paragraph": ("Normal", False),
-}
+OCR_PROMPT = "Extract the plain text from this document image. No hallucination."
 
 
 @app.cls(
     gpu="A10G",
     timeout=600,
-    secrets=[modal.Secret.from_name("textara-r2")],
     min_containers=0,
 )
 class OCRPipeline:
     @modal.enter()
     def load_models(self):
-        import boto3
+        import time
         import torch
-        from botocore.client import Config
-        from detectron2 import model_zoo
-        from detectron2.config import get_cfg
-        from detectron2.engine import DefaultPredictor
-        from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
+        from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
+        from peft import PeftModel
 
-        # --- Layout model (Detectron2) ---
-        print("Downloading layout model from R2...")
-        s3 = boto3.client(
-            "s3",
-            endpoint_url=os.environ["R2_ENDPOINT_URL"],
-            aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
-            aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
-            config=Config(signature_version="s3v4"),
-        )
-        os.makedirs("/weights", exist_ok=True)
-        s3.download_file(
-            os.environ["R2_BUCKET_NAME"],
-            "models/layout/model_final.pth",
-            "/weights/model_final.pth",
-        )
-        print("Layout model downloaded.")
+        t0 = time.time()
 
-        cfg = get_cfg()
-        cfg.merge_from_file(
-            model_zoo.get_config_file("COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml")
-        )
-        cfg.MODEL.ROI_HEADS.NUM_CLASSES = 7
-        cfg.MODEL.WEIGHTS = "/weights/model_final.pth"
-        cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.5
-        cfg.MODEL.DEVICE = "cuda"
-        self.layout_predictor = DefaultPredictor(cfg)
-        print("Layout model loaded.")
+        print(f"Loading {BASE_MODEL_ID} (bf16 base, SDPA)...")
+        base = Qwen2VLForConditionalGeneration.from_pretrained(
+            BASE_MODEL_ID,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+            attn_implementation="sdpa",
+        ).eval()
 
-        # --- Qari OCR model ---
-        print("Loading Qari OCR model from HuggingFace...")
-        model_id = "NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct"
-        self.ocr_processor = AutoProcessor.from_pretrained(
-            model_id, trust_remote_code=True
-        )
-        self.ocr_model = (
-            Qwen2VLForConditionalGeneration.from_pretrained(
-                model_id,
-                device_map="auto",
-                torch_dtype=torch.float16,
-                trust_remote_code=True,
-            ).eval()
-        )
-        print("OCR model loaded.")
+        print(f"Applying Qari LoRA ({LORA_MODEL_ID}) + merging weights...")
+        model = PeftModel.from_pretrained(base, LORA_MODEL_ID)
+        model = model.merge_and_unload()
+        model.generation_config.temperature = None
+        model.generation_config.top_p = None
+        model.generation_config.top_k = None
+        model.eval()
+
+        self.processor = AutoProcessor.from_pretrained(BASE_MODEL_ID, use_fast=True)
+
+        print("Compiling model (reduce-overhead)...")
+        self.model = torch.compile(model, mode="reduce-overhead", fullgraph=False)
+
+        elapsed = time.time() - t0
+        vram_gb = torch.cuda.memory_allocated() / 1e9
+        print(f"Model ready in {elapsed:.1f}s | VRAM: {vram_gb:.2f} GB")
 
     @modal.method()
     def process_pdf(self, pdf_bytes: bytes) -> bytes:
-        """
-        Takes raw PDF bytes, returns raw DOCX bytes.
-        """
-        from pdf2image import convert_from_bytes
+        """Takes raw PDF bytes, returns raw DOCX bytes."""
+        import fitz
+        import torch
         from docx import Document
         from docx.shared import Pt, RGBColor
         from docx.enum.text import WD_ALIGN_PARAGRAPH
         from docx.oxml.ns import qn
         from docx.oxml import OxmlElement
-        import cv2
-        import numpy as np
+        from PIL import Image
+        from qwen_vl_utils import process_vision_info
 
-        print("Converting PDF to images...")
-        pages = convert_from_bytes(pdf_bytes, dpi=300)
-        print(f"  {len(pages)} pages")
+        pdf_doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+        n_pages = len(pdf_doc)
+        print(f"PDF: {n_pages} page(s)")
 
+        pages_text = []
+        for i, page in enumerate(pdf_doc, 1):
+            print(f"  Page {i}/{n_pages} — rendering...")
+            mat = fitz.Matrix(DPI / 72, DPI / 72)
+            pix = page.get_pixmap(matrix=mat, colorspace=fitz.csRGB)
+            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+
+            print(f"  Page {i}/{n_pages} — OCR ({img.width}x{img.height}px)...")
+            messages = [{
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": img, "max_pixels": MAX_PIXELS},
+                    {"type": "text", "text": OCR_PROMPT},
+                ],
+            }]
+
+            text_input = self.processor.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            image_inputs, video_inputs = process_vision_info(messages)
+            inputs = self.processor(
+                text=[text_input],
+                images=image_inputs,
+                videos=video_inputs,
+                padding=True,
+                return_tensors="pt",
+            ).to(self.model.device)
+
+            with torch.inference_mode():
+                ids = self.model.generate(
+                    **inputs,
+                    max_new_tokens=2048,
+                    do_sample=False,
+                    num_beams=1,
+                )
+
+            trimmed = ids[:, inputs["input_ids"].shape[1]:]
+            text = self.processor.batch_decode(
+                trimmed,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=True,
+            )[0].strip()
+
+            print(f"  Page {i}/{n_pages} — {len(text)} chars extracted")
+            pages_text.append(text)
+
+        pdf_doc.close()
+
+        # Build DOCX
         doc = Document()
-        _configure_rtl_document(doc)
 
-        for page_num, page_img in enumerate(pages):
-            print(f"Processing page {page_num + 1}/{len(pages)}")
+        sectPr = doc.sections[0]._sectPr
+        bidi_el = OxmlElement("w:bidi")
+        sectPr.append(bidi_el)
 
-            page_cv = cv2.cvtColor(np.array(page_img), cv2.COLOR_RGB2BGR)
-            outputs = self.layout_predictor(page_cv)
-            instances = outputs["instances"].to("cpu")
-            regions = _extract_regions(instances, page_img)
+        for page_num, text in enumerate(pages_text, 1):
+            if page_num > 1:
+                sep = doc.add_paragraph(f"-- Page {page_num} --")
+                sep.alignment = WD_ALIGN_PARAGRAPH.CENTER
+                for run in sep.runs:
+                    run.font.color.rgb = RGBColor(0x99, 0x99, 0x99)
+                    run.font.size = Pt(9)
 
-            if not regions:
-                text = self._ocr_image(page_img)
-                if text.strip():
-                    _add_paragraph(doc, text, "Normal")
-                continue
-
-            for region in regions:
-                label = LABEL_MAP.get(region["class_id"], "paragraph")
-                if label in SKIP_LABELS:
+            for line in text.split("\n"):
+                line = line.strip()
+                if not line:
+                    doc.add_paragraph("")
                     continue
-                cropped = page_img.crop(region["bbox"])
-                text = self._ocr_image(cropped)
-                if not text.strip():
-                    continue
-                style_name, bold = STYLE_MAP.get(label, ("Normal", False))
-                _add_paragraph(doc, text, style_name, bold)
+                para = doc.add_paragraph(line)
+                para.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+
+                pPr = para._p.get_or_add_pPr()
+                bidi = OxmlElement("w:bidi")
+                bidi.set(qn("w:val"), "1")
+                pPr.append(bidi)
+
+                for run in para.runs:
+                    run.font.name = "Arial"
+                    run.font.size = Pt(12)
 
         buf = io.BytesIO()
         doc.save(buf)
         print("Done.")
         return buf.getvalue()
-
-    def _ocr_image(self, pil_image) -> str:
-        """Run Qari OCR on a PIL image, return extracted Arabic text."""
-        import torch
-        from qwen_vl_utils import process_vision_info
-
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
-            pil_image.save(tmp.name)
-            tmp_path = tmp.name
-
-        try:
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "image", "image": f"file://{tmp_path}"},
-                        {
-                            "type": "text",
-                            "text": "Extract the plain text from this document image. No hallucination.",
-                        },
-                    ],
-                }
-            ]
-            text_input = self.ocr_processor.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
-            image_inputs, _ = process_vision_info(messages)
-            inputs = self.ocr_processor(
-                text=[text_input],
-                images=image_inputs,
-                padding=True,
-                return_tensors="pt",
-            ).to("cuda")
-
-            with torch.inference_mode():
-                generated_ids = self.ocr_model.generate(
-                    **inputs,
-                    max_new_tokens=512,
-                    do_sample=False,
-                    num_beams=1,
-                )
-
-            trimmed = [
-                out[len(inp) :] for inp, out in zip(inputs.input_ids, generated_ids)
-            ]
-            return self.ocr_processor.batch_decode(
-                trimmed,
-                skip_special_tokens=True,
-                clean_up_tokenization_spaces=True,
-            )[0]
-        finally:
-            os.unlink(tmp_path)
-
-
-def _extract_regions(instances, page_img) -> list:
-    """
-    Extract detected regions sorted in Arabic reading order:
-    top-to-bottom rows, right-to-left within each row.
-    Rows are grouped by a vertical overlap tolerance.
-    """
-    if len(instances) == 0:
-        return []
-
-    boxes = instances.pred_boxes.tensor.numpy()
-    scores = instances.scores.numpy()
-    classes = instances.pred_classes.numpy()
-
-    regions = []
-    for box, score, cls in zip(boxes, scores, classes):
-        x1, y1, x2, y2 = map(int, box)
-        regions.append({
-            "bbox": (x1, y1, x2, y2),
-            "class_id": int(cls),
-            "score": float(score),
-        })
-
-    # Sort top-to-bottom by y1
-    regions.sort(key=lambda r: r["bbox"][1])
-
-    # Group into rows (overlap tolerance: 20px)
-    rows = []
-    for region in regions:
-        placed = False
-        for row in rows:
-            rep = row[0]
-            if region["bbox"][1] < rep["bbox"][3] + 20:
-                row.append(region)
-                placed = True
-                break
-        if not placed:
-            rows.append([region])
-
-    # Sort each row RTL (right-to-left: descending x1)
-    sorted_regions = []
-    for row in rows:
-        row.sort(key=lambda r: -r["bbox"][0])
-        sorted_regions.extend(row)
-
-    return sorted_regions
-
-
-def _configure_rtl_document(doc) -> None:
-    """Set document defaults for RTL Arabic text."""
-    from docx.oxml.ns import qn
-    from docx.oxml import OxmlElement
-    from docx.shared import Pt
-
-    # Set RTL on Normal paragraph style
-    pPr = doc.styles["Normal"].paragraph_format._element
-    bidi = OxmlElement("w:bidi")
-    pPr.append(bidi)
-
-    # Set Arabic font for all heading/body styles
-    for style_name in ("Normal", "Heading 1", "Heading 2", "Heading 3"):
-        style = doc.styles[style_name]
-        style.font.name = "Arial"
-        rPr = style.element.get_or_add_rPr()
-        rFonts = OxmlElement("w:rFonts")
-        rFonts.set(qn("w:cs"), "Arial")
-        rPr.append(rFonts)
-
-
-def _add_paragraph(doc, text: str, style_name: str = "Normal", bold: bool = False) -> None:
-    """Add an RTL paragraph to the document."""
-    from docx.oxml.ns import qn
-    from docx.oxml import OxmlElement
-    from docx.enum.text import WD_ALIGN_PARAGRAPH
-
-    para = doc.add_paragraph(style=style_name)
-    para.alignment = WD_ALIGN_PARAGRAPH.RIGHT
-
-    pPr = para._p.get_or_add_pPr()
-    bidi = OxmlElement("w:bidi")
-    pPr.append(bidi)
-
-    run = para.add_run(text)
-    run.bold = bold
-    rPr = run._r.get_or_add_rPr()
-    cs = OxmlElement("w:cs")
-    rPr.append(cs)


### PR DESCRIPTION
## Summary
- Merges `dev` into `main` to trigger the production deploy pipeline
- Brings in the Modal OCR pipeline rewrite (PR #4) and GHA build cache re-enable (PR #3)
- Fixes the live crash: old deployment was calling `from_pretrained` directly on `NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct` (LoRA adapter only — no full model weights), causing repeated `OSError` on every cold start

## Root cause
The deployed `modal_app.py` was an older version that tried to load the Qari model as a standalone model. The Qari HuggingFace repo only contains LoRA adapter weights, not full model weights — so every container cold start failed with:
```
OSError: NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct does not appear to have a file
named pytorch_model.bin, model.safetensors...
```

## What the fix does
Rewrites `modal_app.py` to use the correct two-step loading:
1. Load `Qwen/Qwen2-VL-2B-Instruct` as the bf16 base model (SDPA attention)
2. Apply the Qari LoRA via `PeftModel.from_pretrained`, then `merge_and_unload()`

## Test plan
- [ ] Confirm deploy workflow completes successfully after merge
- [ ] Trigger a test conversion from the dashboard and verify OCR completes without error
- [ ] Check Modal logs: should see "Model ready in Xs | VRAM: X.XX GB" instead of OSError

🤖 Generated with [Claude Code](https://claude.com/claude-code)