### PR TITLE
feat: redesign frontend with design token system and new layout

### DIFF
--- a/frontend/src/components/auth/LoginModal.jsx
+++ b/frontend/src/components/auth/LoginModal.jsx
@@ -57,7 +57,7 @@ const LoginModal = ({ isOpen, onClose }) => {
               required
               value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })}
-              className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="field-input"
             />
           </div>
           <div>
@@ -78,13 +78,13 @@ const LoginModal = ({ isOpen, onClose }) => {
               required
               value={form.password}
               onChange={(e) => setForm({ ...form, password: e.target.value })}
-              className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="field-input"
             />
           </div>
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors disabled:opacity-60"
+            className="btn-primary w-full py-2.5 justify-center"
           >
             {loading ? t("auth.login.submitting") : t("auth.login.submit")}
           </button>

--- a/frontend/src/components/auth/SignupModal.jsx
+++ b/frontend/src/components/auth/SignupModal.jsx
@@ -3,27 +3,79 @@ import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { GoogleLogin } from "@react-oauth/google";
 import toast from "react-hot-toast";
+import { Check, X, Eye, EyeOff } from "lucide-react";
 import Modal from "../ui/Modal";
 import { useAuth } from "../../auth/AuthContext";
 import { registerUser, googleAuth } from "../../features/auth/authservice";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+const PASSWORD_RULES = [
+  { key: "minLength", label: "8+ characters",          test: (p) => p.length >= 8 },
+  { key: "uppercase", label: "Uppercase (A–Z)",         test: (p) => /[A-Z]/.test(p) },
+  { key: "number",    label: "Number (0–9)",            test: (p) => /[0-9]/.test(p) },
+  { key: "special",   label: "Special character",       test: (p) => /[^A-Za-z0-9]/.test(p) },
+];
+
+function isStrongPassword(p) { return PASSWORD_RULES.every((r) => r.test(p)); }
+
+function PasswordStrengthMeter({ password }) {
+  if (!password) return null;
+  const passed = PASSWORD_RULES.filter((r) => r.test(password)).length;
+  const pct = (passed / PASSWORD_RULES.length) * 100;
+  const [barColor] = pct <= 25 ? ["bg-red-500"] : pct <= 50 ? ["bg-amber-500"] : pct <= 75 ? ["bg-yellow-400"] : ["bg-emerald-500"];
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <div className="h-0.5 bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
+        <div className={`h-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+      </div>
+      <ul className="grid grid-cols-2 gap-x-3 gap-y-0.5">
+        {PASSWORD_RULES.map((r) => {
+          const ok = r.test(password);
+          return (
+            <li key={r.key} className={`text-[11px] flex items-center gap-1 ${ok ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-400 dark:text-zinc-500"}`}>
+              {ok ? <Check className="w-3 h-3 shrink-0" /> : <div className="w-3 h-3 shrink-0 border border-current rounded-full opacity-40" />}
+              {r.label}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
 
 function SignupModal({ isOpen, onClose }) {
   const { t } = useTranslation();
   const { login } = useAuth();
   const navigate = useNavigate();
-  const [form, setForm] = useState({ name: "", email: "", password: "", confirm: "" });
-  const [loading, setLoading] = useState(false);
+
+  const [form, setForm]             = useState({ name: "", email: "", password: "", confirm: "" });
+  const [touched, setTouched]       = useState({});
+  const [showPassword, setShowPwd]  = useState(false);
+  const [loading, setLoading]       = useState(false);
   const [registered, setRegistered] = useState(false);
+
+  const errors = {
+    name:     !form.name.trim()                 ? "Required."             : "",
+    email:    !form.email.trim()                ? "Required."             :
+              !EMAIL_RE.test(form.email)        ? "Invalid email."        : "",
+    password: !form.password                   ? "Required."             :
+              !isStrongPassword(form.password) ? "Too weak."             : "",
+    confirm:  form.confirm !== form.password   ? "Passwords don't match." : "",
+  };
+
+  const isFormValid = Object.values(errors).every((e) => !e);
+  const blur = (f) => setTouched((t) => ({ ...t, [f]: true }));
+  const show = (f) => touched[f] && errors[f];
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (form.password !== form.confirm) {
-      toast.error(t("auth.password.mismatch"));
-      return;
-    }
+    setTouched({ name: true, email: true, password: true, confirm: true });
+    if (!isFormValid) return;
     setLoading(true);
     try {
-      await registerUser({ name: form.name, email: form.email, password: form.password });
+      await registerUser({ name: form.name.trim(), email: form.email.trim().toLowerCase(), password: form.password });
       setRegistered(true);
     } catch (err) {
       toast.error(err?.response?.data?.detail || "Registration failed. Please try again.");
@@ -49,63 +101,86 @@ function SignupModal({ isOpen, onClose }) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={t("auth.signup.title")}>
       {registered ? (
-        <div className="text-center space-y-4">
-          <p className="text-sm text-zinc-500 dark:text-zinc-400">
-            {t("auth.signup.checkInboxTitle")}
-          </p>
-          <button
-            onClick={onClose}
-            className="text-sm text-indigo-500 hover:text-indigo-600 font-medium transition-colors"
-          >
+        <div className="space-y-4 text-center">
+          <div className="w-10 h-10 border border-zinc-200 dark:border-zinc-700 flex items-center justify-center mx-auto">
+            <span className="text-lg">✉️</span>
+          </div>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("auth.signup.checkInboxTitle")}</p>
+          <button onClick={onClose} className="text-sm text-indigo-500 hover:text-indigo-600 font-medium transition-colors">
             {t("auth.signup.backToSignIn")}
           </button>
         </div>
       ) : (
-        <div className="space-y-5">
+        <div className="space-y-4">
           <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("auth.signup.subtitle")}</p>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {[
-              { key: "name", type: "text", label: t("auth.signup.name") },
-              { key: "email", type: "email", label: t("auth.signup.email") },
-              { key: "password", type: "password", label: t("auth.signup.password") },
-              { key: "confirm", type: "password", label: t("auth.signup.confirmPassword") },
-            ].map(({ key, type, label }) => (
-              <div key={key}>
-                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
-                  {label}
-                </label>
-                <input
-                  type={type}
-                  required
-                  value={form[key]}
-                  onChange={(e) => setForm({ ...form, [key]: e.target.value })}
-                  className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                />
+          <form onSubmit={handleSubmit} className="space-y-3" noValidate>
+
+            {/* Name */}
+            <div>
+              <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">Full name</label>
+              <input type="text" autoComplete="name" value={form.name} placeholder="Your name"
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                onBlur={() => blur("name")}
+                className={`field-input ${show("name") ? "border-red-400" : ""}`} />
+              {show("name") && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
+            </div>
+
+            {/* Email */}
+            <div>
+              <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">Email</label>
+              <div className="relative">
+                <input type="email" autoComplete="email" value={form.email} placeholder="you@example.com"
+                  onChange={(e) => setForm({ ...form, email: e.target.value })}
+                  onBlur={() => blur("email")}
+                  className={`field-input pr-8 ${show("email") ? "border-red-400" : touched.email && !errors.email ? "border-emerald-400" : ""}`} />
+                {touched.email && !errors.email && <Check className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-emerald-500 pointer-events-none" />}
               </div>
-            ))}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full py-2.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors disabled:opacity-60"
-            >
+              {show("email") && <p className="mt-1 text-xs text-red-500">{errors.email}</p>}
+            </div>
+
+            {/* Password */}
+            <div>
+              <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">Password</label>
+              <div className="relative">
+                <input type={showPassword ? "text" : "password"} autoComplete="new-password"
+                  value={form.password}
+                  onChange={(e) => setForm({ ...form, password: e.target.value })}
+                  onBlur={() => blur("password")}
+                  className={`field-input pr-9 ${show("password") && errors.password ? "border-red-400" : ""}`} />
+                <button type="button" onClick={() => setShowPwd((v) => !v)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600">
+                  {showPassword ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+                </button>
+              </div>
+              <PasswordStrengthMeter password={form.password} />
+            </div>
+
+            {/* Confirm */}
+            <div>
+              <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">Confirm password</label>
+              <input type="password" autoComplete="new-password" value={form.confirm}
+                onChange={(e) => setForm({ ...form, confirm: e.target.value })}
+                onBlur={() => blur("confirm")}
+                className={`field-input ${show("confirm") ? "border-red-400" : form.confirm && !errors.confirm ? "border-emerald-400" : ""}`} />
+              {show("confirm") && <p className="mt-1 text-xs text-red-500">{errors.confirm}</p>}
+            </div>
+
+            <button type="submit" disabled={loading} className="btn-primary w-full py-2.5 justify-center mt-1">
               {loading ? t("auth.signup.submitting") : t("auth.signup.submit")}
             </button>
           </form>
-          <div className="relative flex items-center gap-3">
-            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-700" />
+
+          <div className="flex items-center gap-3">
+            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
             <span className="text-xs text-zinc-400">{t("auth.signup.orSignUpWith")}</span>
-            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-700" />
+            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
           </div>
           <div className="flex justify-center">
             <GoogleLogin onSuccess={handleGoogle} onError={() => toast.error("Google sign-up failed.")} />
           </div>
           <p className="text-center text-sm text-zinc-500 dark:text-zinc-400">
             {t("auth.signup.hasAccount")}{" "}
-            <Link
-              to="/login"
-              onClick={onClose}
-              className="text-indigo-500 hover:text-indigo-600 font-medium transition-colors"
-            >
+            <Link to="/login" onClick={onClose} className="text-indigo-500 hover:text-indigo-600 font-medium transition-colors">
               {t("auth.signup.signIn")}
             </Link>
           </p>

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -17,17 +17,18 @@ function NavItem({ to, label, icon: Icon, badge }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+        [
+          "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors relative",
           isActive
-            ? "bg-indigo-50 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400"
-            : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-800"
-        }`
+            ? "text-indigo-600 dark:text-indigo-400 bg-indigo-50/80 dark:bg-indigo-500/8 border-l-2 border-indigo-500 dark:border-indigo-400 pl-[10px]"
+            : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 border-l-2 border-transparent pl-[10px] hover:bg-zinc-50 dark:hover:bg-zinc-800/50",
+        ].join(" ")
       }
     >
-      <Icon className="w-4 h-4 shrink-0" />
+      <Icon className="w-3.5 h-3.5 shrink-0" />
       <span className="flex-1">{label}</span>
       {badge && (
-        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400">
+        <span className="text-[9px] font-semibold tracking-widest uppercase text-zinc-400 dark:text-zinc-600">
           {badge}
         </span>
       )}
@@ -46,34 +47,41 @@ const Sidebar = ({ isOpen, onClose }) => {
   return (
     <aside
       className={`
-        fixed top-14 left-0 rtl:left-auto rtl:right-0 z-40 h-[calc(100vh-3.5rem)] w-60
+        fixed top-12 left-0 rtl:left-auto rtl:right-0 z-40
+        h-[calc(100vh-3rem)] w-52
         bg-white dark:bg-zinc-950
-        border-r rtl:border-r-0 rtl:border-l border-zinc-200/80 dark:border-zinc-800/80
-        transform transition-transform duration-300 ease-in-out
+        border-r rtl:border-r-0 rtl:border-l border-zinc-200 dark:border-zinc-800
+        transform transition-transform duration-200 ease-in-out
         flex flex-col
         ${isOpen ? "translate-x-0" : "-translate-x-full rtl:translate-x-full"}
       `}
     >
-      <div className="flex-1 overflow-y-auto p-3">
-        <div className="flex flex-col gap-0.5">
-          <NavItem to="/dashboard" label={t("sidebar.dashboard")} icon={LayoutDashboard} />
-          <NavItem to="/convert" label={t("sidebar.convert")} icon={FileOutput} />
-          <NavItem to="/coming-soon" label={t("sidebar.translate")} icon={Languages} badge="Soon" />
+      {/* Section: Main nav */}
+      <div className="flex-1 overflow-y-auto py-4">
+        <p className="section-label px-4 mb-3">Navigation</p>
+        <div className="flex flex-col">
+          <NavItem to="/dashboard"   label={t("sidebar.dashboard")}    icon={LayoutDashboard} />
+          <NavItem to="/convert"     label={t("sidebar.convert")}      icon={FileOutput} />
+          <NavItem to="/coming-soon" label={t("sidebar.translate")}    icon={Languages}  badge="Soon" />
           <NavItem to="/coming-soon" label={t("sidebar.authenticate")} icon={ShieldCheck} badge="Soon" />
         </div>
-        <div className="mt-4 pt-4 border-t border-zinc-100 dark:border-zinc-800/80 flex flex-col gap-0.5">
-          <NavItem to="/pricing" label={t("sidebar.pricing")} icon={Tag} />
+
+        <div className="mx-4 my-4 border-t border-zinc-100 dark:border-zinc-800" />
+
+        <p className="section-label px-4 mb-3">Account</p>
+        <div className="flex flex-col">
+          <NavItem to="/pricing"  label={t("sidebar.pricing")}  icon={Tag} />
           <NavItem to="/settings" label={t("sidebar.settings")} icon={Settings} />
         </div>
       </div>
-      <div className="p-3 border-t border-zinc-100 dark:border-zinc-800/80 space-y-2">
+
+      {/* Bottom */}
+      <div className="px-4 py-3 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
         <div className="flex items-center gap-1 lg:hidden">
           <LanguageToggle />
           <DarkModeToggle />
         </div>
-        <p className="text-[11px] text-zinc-400 dark:text-zinc-600 text-center">
-          © {new Date().getFullYear()} Textara
-        </p>
+        <p className="section-label">© {new Date().getFullYear()} Textara</p>
       </div>
     </aside>
   );

--- a/frontend/src/components/layout/TopNavbar.jsx
+++ b/frontend/src/components/layout/TopNavbar.jsx
@@ -8,20 +8,18 @@ import DarkModeToggle from "../ui/DarkModeToggle";
 
 const TopNavbar = ({ isSidebarOpen, setIsSidebarOpen, user, onLogout, openLogin, openRegister }) => {
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 h-14 glass border-b border-zinc-200/80 dark:border-zinc-800/80">
+    <header className="fixed top-0 left-0 right-0 z-50 h-12 bg-white dark:bg-zinc-950 border-b border-zinc-200 dark:border-zinc-800">
       <nav className="flex items-center h-full px-4 gap-2">
-        <div className="flex items-center gap-1 shrink-0">
-          <button
-            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-            className="p-2 rounded-lg text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-            aria-label="Toggle sidebar"
-          >
-            <Menu className="h-5 w-5" />
-          </button>
-          <Link to="/" className="flex items-center gap-2 ml-1 shrink-0">
-            <Logo className="h-6 w-auto fill-zinc-900 dark:fill-white" />
-          </Link>
-        </div>
+        <button
+          onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          className="p-1.5 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+          aria-label="Toggle sidebar"
+        >
+          <Menu className="h-4 w-4" />
+        </button>
+        <Link to="/" className="flex items-center gap-2 ml-2 shrink-0">
+          <Logo className="h-4 w-auto fill-zinc-900 dark:fill-white" />
+        </Link>
         <div className="flex-1" />
         <div className="flex items-center gap-1 shrink-0">
           <div className="hidden lg:flex items-center gap-1">

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -2,23 +2,16 @@ import React from "react";
 import clsx from "clsx";
 
 const Button = ({ children, variant = "primary", className = "", ...props }) => {
-  const base =
-    "px-4 py-2 font-semibold transition duration-200 rounded-md focus:outline-none focus:ring-2";
-
   const variants = {
-    primary:
-      "bg-secondary text-white hover:bg-secondary-dark focus:ring-secondary",
-    secondary:
-      "border border-secondary text-secondary hover:bg-secondary hover:text-white focus:ring-secondary",
-    outline:
-      "border border-content-muted text-content-muted hover:bg-background-subtle dark:hover:bg-primary-light hover:text-secondary focus:ring-secondary",
-    danger:
-      "bg-red-600 text-white hover:bg-red-700 focus:ring-red-400",
-    unstyled: "",
+    primary:   "btn-primary",
+    secondary: "btn-secondary",
+    outline:   "btn-secondary",
+    danger:    "btn-danger",
+    unstyled:  "",
   };
 
   return (
-    <button className={clsx(base, variants[variant], className)} {...props}>
+    <button className={clsx(variants[variant], className)} {...props}>
       {children}
     </button>
   );

--- a/frontend/src/components/ui/DarkModeToggle.jsx
+++ b/frontend/src/components/ui/DarkModeToggle.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
-import clsx from "clsx";
 
-const DarkModeToggle = ({ className }) => {
+const DarkModeToggle = ({ className = "" }) => {
   const [isDark, setIsDark] = useState(() => {
     const theme = localStorage.getItem("theme");
     return theme ? theme === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -22,12 +21,7 @@ const DarkModeToggle = ({ className }) => {
   return (
     <button
       onClick={() => setIsDark(!isDark)}
-      className={clsx(
-        "p-2 rounded-lg transition-colors",
-        "text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200",
-        "hover:bg-zinc-100 dark:hover:bg-zinc-800",
-        className
-      )}
+      className={`p-1.5 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors ${className}`}
       aria-label="Toggle dark mode"
     >
       {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}

--- a/frontend/src/components/ui/LanguageToggle.jsx
+++ b/frontend/src/components/ui/LanguageToggle.jsx
@@ -9,7 +9,7 @@ const LanguageToggle = () => {
     <button
       onClick={() => i18n.changeLanguage(isAr ? "en" : "ar")}
       title={isAr ? "Switch to English" : "التبديل إلى العربية"}
-      className="flex items-center justify-center w-8 h-8 rounded-lg text-sm font-semibold text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+      className="flex items-center justify-center w-7 h-7 text-xs font-semibold text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
     >
       {isAr ? "EN" : "ع"}
     </button>

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -16,10 +16,11 @@ function Modal({ isOpen, onClose, title, children }) {
         className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
       />
-      <div className="relative w-full max-w-md animate-slide-up glass-card rounded-2xl shadow-2xl shadow-black/30 overflow-hidden">
+      <div className="relative w-full max-w-md animate-slide-up bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 border-t-2 border-t-indigo-500 shadow-2xl shadow-black/30 overflow-hidden" style={{ borderRadius: 2 }}>
         {title && (
-          <div className="px-6 pt-6 pb-4 border-b border-zinc-100 dark:border-zinc-800">
+          <div className="px-6 pt-5 pb-4 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between">
             <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">{title}</h2>
+            <button onClick={onClose} className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors text-lg leading-none">×</button>
           </div>
         )}
         <div className="p-6">{children}</div>

--- a/frontend/src/components/ui/UserMenu.jsx
+++ b/frontend/src/components/ui/UserMenu.jsx
@@ -14,75 +14,58 @@ const UserMenu = ({ user, onLogout, openLogin, openRegister }) => {
       <MenuButton as={Fragment}>
         <button
           className={clsx(
-            "focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-950",
+            "focus:outline-none focus-visible:ring-1 focus-visible:ring-indigo-500 transition-colors",
             user
-              ? "w-8 h-8 rounded-full bg-gradient-to-br from-indigo-500 to-violet-600 text-white flex items-center justify-center text-sm font-semibold hover:opacity-90 transition-opacity"
-              : "p-2 rounded-lg text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+              ? "w-7 h-7 bg-indigo-500 text-white flex items-center justify-center text-xs font-bold hover:bg-indigo-600"
+              : "p-1.5 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
           )}
+          style={{ borderRadius: 2 }}
         >
-          {user ? (
-            (user.name?.[0]?.toUpperCase()) || "U"
-          ) : (
-            <User className="w-4 h-4" />
-          )}
+          {user ? (user.name?.[0]?.toUpperCase() || "U") : <User className="w-4 h-4" />}
         </button>
       </MenuButton>
       <MenuItems
         anchor={isRtl ? "bottom start" : "bottom end"}
         className={clsx(
-          "w-52 glass-card rounded-xl shadow-xl shadow-black/10 dark:shadow-black/40 py-1 focus:outline-none z-50",
+          "w-52 py-1 focus:outline-none z-50",
           isRtl ? "origin-top-left" : "origin-top-right"
         )}
+        style={{
+          background: 'white',
+          border: '1px solid rgb(228 228 231)',
+          borderRadius: 2,
+          boxShadow: '0 4px 24px rgba(0,0,0,0.12)',
+        }}
       >
         {user ? (
           <>
-            <div className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800">
-              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">{user.name}</p>
-              <p className="text-xs text-zinc-400 dark:text-zinc-500 truncate mt-0.5">{user.email}</p>
+            <div className="px-3 py-2.5 border-b border-zinc-100">
+              <p className="text-sm font-semibold text-zinc-900 truncate">{user.name}</p>
+              <p className="text-xs text-zinc-400 truncate mt-0.5">{user.email}</p>
             </div>
             <div className="p-1">
+              {[
+                { icon: LayoutDashboard, label: t("userMenu.dashboard"), to: "/dashboard" },
+                { icon: Settings,        label: t("userMenu.settings"),  to: "/settings" },
+              ].map(({ icon: Icon, label, to }) => (
+                <MenuItem key={to} as={Fragment}>
+                  {({ focus }) => (
+                    <Link to={to}
+                      className={clsx("flex items-center gap-2 px-3 py-2 text-sm transition-colors", focus ? "bg-zinc-50 text-zinc-900" : "text-zinc-600")}
+                      style={{ borderRadius: 2 }}>
+                      <Icon className="w-3.5 h-3.5 shrink-0" />
+                      {label}
+                    </Link>
+                  )}
+                </MenuItem>
+              ))}
+              <div className="my-1 border-t border-zinc-100" />
               <MenuItem as={Fragment}>
                 {({ focus }) => (
-                  <Link
-                    to="/dashboard"
-                    className={clsx(
-                      "flex items-center gap-2.5 px-3 py-2 text-sm rounded-lg transition-colors",
-                      "text-zinc-600 dark:text-zinc-300",
-                      focus && "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
-                    )}
-                  >
-                    <LayoutDashboard className="w-4 h-4 shrink-0" />
-                    {t("userMenu.dashboard")}
-                  </Link>
-                )}
-              </MenuItem>
-              <MenuItem as={Fragment}>
-                {({ focus }) => (
-                  <Link
-                    to="/settings"
-                    className={clsx(
-                      "flex items-center gap-2.5 px-3 py-2 text-sm rounded-lg transition-colors",
-                      "text-zinc-600 dark:text-zinc-300",
-                      focus && "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
-                    )}
-                  >
-                    <Settings className="w-4 h-4 shrink-0" />
-                    {t("userMenu.settings")}
-                  </Link>
-                )}
-              </MenuItem>
-              <div className="my-1 border-t border-zinc-100 dark:border-zinc-800" />
-              <MenuItem as={Fragment}>
-                {({ focus }) => (
-                  <button
-                    onClick={onLogout}
-                    className={clsx(
-                      "w-full flex items-center gap-2.5 px-3 py-2 text-sm rounded-lg transition-colors",
-                      "text-red-500 dark:text-red-400",
-                      focus && "bg-red-50 dark:bg-red-500/10"
-                    )}
-                  >
-                    <LogOut className="w-4 h-4 shrink-0" />
+                  <button onClick={onLogout}
+                    className={clsx("w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors", focus ? "bg-red-50 text-red-600" : "text-red-500")}
+                    style={{ borderRadius: 2 }}>
+                    <LogOut className="w-3.5 h-3.5 shrink-0" />
                     {t("userMenu.signOut")}
                   </button>
                 )}
@@ -93,28 +76,18 @@ const UserMenu = ({ user, onLogout, openLogin, openRegister }) => {
           <div className="p-1">
             <MenuItem as={Fragment}>
               {({ focus }) => (
-                <button
-                  onClick={openLogin}
-                  className={clsx(
-                    "w-full text-left px-3 py-2 text-sm rounded-lg transition-colors",
-                    "text-zinc-600 dark:text-zinc-300",
-                    focus && "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
-                  )}
-                >
+                <button onClick={openLogin}
+                  className={clsx("w-full text-left px-3 py-2 text-sm transition-colors", focus ? "bg-zinc-50 text-zinc-900" : "text-zinc-600")}
+                  style={{ borderRadius: 2 }}>
                   {t("userMenu.signIn")}
                 </button>
               )}
             </MenuItem>
             <MenuItem as={Fragment}>
               {({ focus }) => (
-                <button
-                  onClick={openRegister}
-                  className={clsx(
-                    "w-full text-left px-3 py-2 text-sm rounded-lg transition-colors",
-                    "text-zinc-600 dark:text-zinc-300",
-                    focus && "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
-                  )}
-                >
+                <button onClick={openRegister}
+                  className={clsx("w-full text-left px-3 py-2 text-sm font-medium transition-colors", focus ? "bg-indigo-50 text-indigo-600" : "text-indigo-500")}
+                  style={{ borderRadius: 2 }}>
                   {t("userMenu.createAccount")}
                 </button>
               )}

--- a/frontend/src/layouts/AuthLayout.jsx
+++ b/frontend/src/layouts/AuthLayout.jsx
@@ -6,26 +6,79 @@ import LanguageToggle from "../components/ui/LanguageToggle";
 
 function AuthLayout({ children }) {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 flex flex-col">
-      <header className="flex items-center justify-between px-6 h-14">
-        <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
-          <Logo className="h-6 w-auto fill-zinc-900 dark:fill-white" />
-        </Link>
-        <div className="flex items-center gap-1">
-          <LanguageToggle />
-          <DarkModeToggle />
+    <div className="min-h-screen flex bg-white dark:bg-zinc-950">
+
+      {/* ── Left panel: brand / illustration ── */}
+      <div className="hidden lg:flex flex-col w-[44%] bg-zinc-950 dark:bg-zinc-900 relative overflow-hidden">
+        {/* Subtle grid texture */}
+        <div className="absolute inset-0 [background-image:linear-gradient(rgba(99,102,241,0.04)_1px,transparent_1px),linear-gradient(to_right,rgba(99,102,241,0.04)_1px,transparent_1px)] [background-size:40px_40px]" />
+        <div className="absolute inset-0 bg-gradient-to-t from-zinc-950 via-transparent to-zinc-950/60" />
+
+        {/* Logo */}
+        <div className="relative z-10 p-8">
+          <Link to="/">
+            <Logo className="h-5 w-auto fill-white opacity-90" />
+          </Link>
         </div>
-      </header>
-      <main className="flex-1 flex items-center justify-center px-4 py-10">
-        <div className="w-full max-w-sm">
-          <div className="glass-card rounded-2xl shadow-sm shadow-black/5 dark:shadow-none p-8">
-            {children}
+
+        {/* Center content */}
+        <div className="relative z-10 flex-1 flex flex-col justify-center px-10 pb-16">
+          <div className="space-y-6">
+            {/* Large accent number */}
+            <div className="text-[7rem] font-extrabold leading-none text-white/5 select-none tabular-nums">
+              OCR
+            </div>
+            <div>
+              <h2 className="text-2xl font-bold text-white leading-tight mb-3">
+                Arabic documents,<br />instantly converted.
+              </h2>
+              <p className="text-sm text-zinc-400 leading-relaxed max-w-xs">
+                Upload a scanned Arabic PDF and receive a fully editable Word document in seconds.
+              </p>
+            </div>
+            {/* Mini feature list */}
+            <ul className="space-y-2">
+              {["RTL-accurate text extraction", "GPU-powered processing", "Cloud storage included"].map((f) => (
+                <li key={f} className="flex items-center gap-2.5 text-xs text-zinc-400">
+                  <div className="w-1 h-1 bg-indigo-500 shrink-0" />
+                  {f}
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
-      </main>
-      <footer className="text-center py-5 text-xs text-zinc-400 dark:text-zinc-600">
-        © {new Date().getFullYear()} Textara
-      </footer>
+
+        {/* Bottom mark */}
+        <div className="relative z-10 px-10 py-6 border-t border-zinc-800">
+          <p className="text-xs text-zinc-600">© {new Date().getFullYear()} Textara</p>
+        </div>
+      </div>
+
+      {/* ── Right panel: form ── */}
+      <div className="flex-1 flex flex-col">
+        {/* Top bar */}
+        <header className="flex items-center justify-between px-6 h-12 border-b border-zinc-200 dark:border-zinc-800">
+          <Link to="/" className="lg:hidden">
+            <Logo className="h-4 w-auto fill-zinc-900 dark:fill-white" />
+          </Link>
+          <div className="lg:hidden flex-1" />
+          <div className="flex items-center gap-1 ml-auto">
+            <LanguageToggle />
+            <DarkModeToggle />
+          </div>
+        </header>
+
+        {/* Form area */}
+        <main className="flex-1 flex items-center justify-center px-6 py-10">
+          <div className="w-full max-w-sm animate-slide-up">
+            {children}
+          </div>
+        </main>
+
+        <footer className="px-6 py-4 border-t border-zinc-100 dark:border-zinc-800 text-center">
+          <p className="text-xs text-zinc-400 dark:text-zinc-600">© {new Date().getFullYear()} Textara</p>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
-
 import TopNavbar from "../components/layout/TopNavbar";
 import Sidebar from "../components/layout/Sidebar";
 
@@ -17,13 +16,10 @@ function MainLayout({ children, openLogin, openRegister }) {
     return () => window.removeEventListener("resize", check);
   }, []);
 
-  const handleLogout = () => {
-    logout();
-    navigate("/");
-  };
+  const handleLogout = () => { logout(); navigate("/"); };
 
   return (
-    <div className="min-h-screen w-full bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 font-sans">
+    <div className="min-h-screen w-full bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
       <TopNavbar
         isSidebarOpen={isSidebarOpen}
         setIsSidebarOpen={setIsSidebarOpen}
@@ -33,18 +29,14 @@ function MainLayout({ children, openLogin, openRegister }) {
         openRegister={openRegister}
       />
       <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
-      <div
-        className={`pt-14 transition-[margin] duration-300 ease-in-out min-h-screen ${
-          isSidebarOpen
-            ? "lg:ml-60 rtl:lg:ml-0 rtl:lg:mr-60"
-            : "ml-0 rtl:mr-0"
-        }`}
-      >
-        <main className="p-6 max-w-6xl mx-auto">{children}</main>
+      <div className={`pt-12 transition-[padding] duration-200 ease-in-out min-h-screen ${
+        isSidebarOpen ? "lg:pl-52 rtl:lg:pl-0 rtl:lg:pr-52" : ""
+      }`}>
+        <main className="p-6 max-w-5xl mx-auto">{children}</main>
       </div>
       {isSidebarOpen && (
         <div
-          className="fixed inset-0 z-30 bg-black/30 lg:hidden"
+          className="fixed inset-0 z-30 bg-black/20 lg:hidden"
           onClick={() => setIsSidebarOpen(false)}
         />
       )}

--- a/frontend/src/pages/ComingSoon.jsx
+++ b/frontend/src/pages/ComingSoon.jsx
@@ -1,10 +1,17 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 function ComingSoon() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center">
-      <h1 className="text-4xl font-bold mb-4">🚧 Coming Soon</h1>
-      <p className="text-gray-600">We're working on this feature. Stay tuned!</p>
+    <div className="min-h-screen bg-white dark:bg-zinc-950 flex flex-col items-center justify-center text-center px-4">
+      <div className="text-[7rem] font-extrabold leading-none text-zinc-100 dark:text-zinc-900 select-none mb-6">
+        Soon
+      </div>
+      <h1 className="text-xl font-semibold mb-2">Coming Soon</h1>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400 max-w-xs leading-relaxed mb-8">
+        We're working on this feature. Stay tuned for updates.
+      </p>
+      <Link to="/dashboard" className="btn-secondary px-6 py-2">Back to Dashboard</Link>
     </div>
   );
 }

--- a/frontend/src/pages/ConvertPage.jsx
+++ b/frontend/src/pages/ConvertPage.jsx
@@ -1,68 +1,76 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../auth/AuthContext";
 import toast from "react-hot-toast";
-import { FileText, Upload, Loader2, Zap, Trash2, Download } from "lucide-react";
 import {
-  fetchDocuments,
-  uploadDocument,
-  deleteDocument,
-  convertDocument,
-  getPreviewBlob,
-  downloadDocument,
+  FileText, Upload, Loader2, Zap, Trash2, Download, X,
+  Search, ChevronUp, ChevronDown, ChevronsUpDown, CheckSquare,
+} from "lucide-react";
+import {
+  fetchDocuments, uploadDocument, deleteDocument,
+  convertDocument, getPreviewBlob, downloadDocument,
 } from "../api/docs";
 import PDFViewer from "../components/pdf/PDFViewer";
 
-const STATUS_STYLES = {
-  pending: "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400",
-  processing: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
-  done: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-  failed: "bg-red-500/10 text-red-600 dark:text-red-400",
-};
+// ── Helpers ────────────────────────────────────────────────────────────────
 
-function StatusBadge({ status }) {
+function fmtElapsed(seconds) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+const STATUS_ORDER = { processing: 0, pending: 1, failed: 2, done: 3 };
+
+function sortDocs(docs, key, dir) {
+  return [...docs].sort((a, b) => {
+    let av, bv;
+    if (key === "name")   { av = a.filename.toLowerCase(); bv = b.filename.toLowerCase(); }
+    if (key === "status") { av = STATUS_ORDER[a.status] ?? 9; bv = STATUS_ORDER[b.status] ?? 9; }
+    if (key === "date")   { av = a.last_modified; bv = b.last_modified; }
+    if (av < bv) return dir === "asc" ? -1 : 1;
+    if (av > bv) return dir === "asc" ?  1 : -1;
+    return 0;
+  });
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function StatusText({ status, elapsed }) {
   const { t } = useTranslation();
-  const style = STATUS_STYLES[status] ?? STATUS_STYLES.pending;
+  const cls = {
+    pending:    "status-pending",
+    processing: "status-processing",
+    done:       "status-done",
+    failed:     "status-failed",
+  }[status] ?? "status-pending";
+
   return (
-    <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full ${style}`}>
+    <span className={`inline-flex items-center gap-1 ${cls}`}>
       {status === "processing" && <Loader2 className="w-2.5 h-2.5 animate-spin" />}
       {t(`convert.status.${status}`, { defaultValue: status })}
+      {status === "processing" && elapsed != null && (
+        <span className="opacity-60 font-normal normal-case tracking-normal">· {fmtElapsed(elapsed)}</span>
+      )}
     </span>
   );
 }
 
-function UploadProgress({ filename, progress }) {
+function SortHeader({ label, colKey, sortKey, sortDir, onSort }) {
+  const active = sortKey === colKey;
   return (
-    <div className="rounded-xl border border-indigo-200 dark:border-indigo-500/20 bg-indigo-50 dark:bg-indigo-500/5 p-4 space-y-2">
-      <div className="flex justify-between items-center text-sm">
-        <span className="font-medium truncate max-w-xs text-indigo-700 dark:text-indigo-300">{filename}</span>
-        <span className="text-indigo-400 ml-4 shrink-0 tabular-nums">{progress}%</span>
-      </div>
-      <div className="h-1.5 bg-indigo-100 dark:bg-indigo-500/20 rounded-full overflow-hidden">
-        <div
-          className="h-full bg-indigo-500 rounded-full transition-all duration-150"
-          style={{ width: `${progress}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function SkeletonRow() {
-  return (
-    <div className="p-3 border border-zinc-100 dark:border-zinc-800 rounded-xl flex items-center justify-between gap-3">
-      <div className="flex items-center gap-3 flex-1 min-w-0">
-        <div className="w-8 h-8 rounded-xl bg-zinc-100 dark:bg-zinc-800 animate-pulse shrink-0" />
-        <div className="flex-1 space-y-1.5">
-          <div className="h-3.5 w-48 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-          <div className="h-2.5 w-24 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-        </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="h-5 w-16 bg-zinc-100 dark:bg-zinc-800 rounded-full animate-pulse" />
-        <div className="h-7 w-20 bg-zinc-100 dark:bg-zinc-800 rounded-lg animate-pulse" />
-      </div>
-    </div>
+    <button
+      onClick={() => onSort(colKey)}
+      className="flex items-center gap-1 section-label hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+    >
+      {label}
+      {active
+        ? sortDir === "asc"
+          ? <ChevronUp className="w-3 h-3" />
+          : <ChevronDown className="w-3 h-3" />
+        : <ChevronsUpDown className="w-3 h-3 opacity-40" />
+      }
+    </button>
   );
 }
 
@@ -73,86 +81,99 @@ function Dropzone({ onFile, disabled }) {
 
   const handleFile = (file) => {
     if (!file) return;
-    if (file.type !== "application/pdf") {
-      toast.error(t("convert.onlyPdf"));
-      return;
-    }
-    if (file.size > 50 * 1024 * 1024) {
-      toast.error(t("convert.tooLarge"));
-      return;
-    }
+    if (file.type !== "application/pdf") { toast.error(t("convert.onlyPdf")); return; }
+    if (file.size > 50 * 1024 * 1024)   { toast.error(t("convert.tooLarge")); return; }
     onFile(file);
   };
 
   return (
     <div
       onClick={() => !disabled && inputRef.current?.click()}
-      onDrop={(e) => {
-        e.preventDefault();
-        setDragging(false);
-        handleFile(e.dataTransfer.files?.[0]);
-      }}
+      onDrop={(e) => { e.preventDefault(); setDragging(false); handleFile(e.dataTransfer.files?.[0]); }}
       onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
       onDragLeave={() => setDragging(false)}
       className={[
-        "border-2 border-dashed rounded-2xl px-6 py-10 flex flex-col items-center gap-3 transition-all duration-150 select-none",
+        "border-2 border-dashed py-10 flex flex-col items-center gap-3 select-none transition-all duration-150",
         disabled
-          ? "opacity-50 cursor-not-allowed border-zinc-200 dark:border-zinc-800"
+          ? "opacity-40 cursor-not-allowed border-zinc-200 dark:border-zinc-800"
           : dragging
-          ? "border-indigo-400 bg-indigo-50/60 dark:bg-indigo-500/10 cursor-copy"
-          : "border-zinc-200 dark:border-zinc-700 hover:border-indigo-300 dark:hover:border-indigo-600 hover:bg-zinc-50/60 dark:hover:bg-zinc-800/40 cursor-pointer",
+          ? "border-indigo-400 bg-indigo-50/40 dark:bg-indigo-500/5 cursor-copy"
+          : "border-zinc-200 dark:border-zinc-700 hover:border-indigo-300 dark:hover:border-indigo-700 hover:bg-zinc-50/40 dark:hover:bg-zinc-900/40 cursor-pointer",
       ].join(" ")}
     >
-      <input
-        ref={inputRef}
-        type="file"
-        accept="application/pdf"
-        className="hidden"
-        onChange={(e) => handleFile(e.target.files?.[0])}
-      />
-      <div
-        className={`w-12 h-12 rounded-2xl flex items-center justify-center transition-colors ${
-          dragging ? "bg-indigo-500/15 text-indigo-500" : "bg-zinc-100 dark:bg-zinc-800 text-zinc-400"
-        }`}
-      >
-        <Upload className="w-6 h-6" />
+      <input ref={inputRef} type="file" accept="application/pdf" className="hidden"
+        onChange={(e) => handleFile(e.target.files?.[0])} />
+      <div className={[
+        "w-10 h-10 flex items-center justify-center transition-colors border",
+        dragging
+          ? "border-indigo-300 text-indigo-500 bg-indigo-50 dark:bg-indigo-500/10"
+          : "border-zinc-200 dark:border-zinc-700 text-zinc-400",
+      ].join(" ")}>
+        <Upload className="w-4 h-4" />
       </div>
       <div className="text-center">
-        <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">{t("convert.dropzone.title")}</p>
-        <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-1">{t("convert.dropzone.subtitle")}</p>
+        <p className="text-sm font-medium">{t("convert.dropzone.title")}</p>
+        <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5">{t("convert.dropzone.subtitle")}</p>
       </div>
-      <button
-        type="button"
-        disabled={disabled}
-        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700 border border-zinc-200 dark:border-zinc-700 transition-colors disabled:opacity-50 disabled:pointer-events-none"
-      >
-        <Upload className="w-3.5 h-3.5" />
-        {t("convert.dropzone.browse")}
-      </button>
+      <div className="flex items-center gap-3">
+        <button type="button" disabled={disabled} className="btn-secondary text-xs px-3 py-1.5 gap-1.5">
+          <Upload className="w-3 h-3" />
+          {t("convert.dropzone.browse")}
+        </button>
+        <span className="text-xs text-zinc-300 dark:text-zinc-700 select-none">
+          Press <kbd className="px-1 py-0.5 text-[10px] border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 font-mono">U</kbd> to browse
+        </span>
+      </div>
     </div>
   );
 }
 
+function UploadProgress({ filename, progress }) {
+  return (
+    <div className="border border-indigo-200 dark:border-indigo-500/20 bg-indigo-50/40 dark:bg-indigo-500/5 px-4 py-3 space-y-1.5">
+      <div className="flex justify-between items-center">
+        <span className="text-xs font-medium text-indigo-700 dark:text-indigo-300 truncate max-w-xs">{filename}</span>
+        <span className="text-xs text-zinc-400 tabular-nums ml-4 shrink-0">{progress}%</span>
+      </div>
+      <div className="h-0.5 bg-indigo-100 dark:bg-indigo-500/20 overflow-hidden">
+        <div className="h-full bg-indigo-500 transition-all duration-150" style={{ width: `${progress}%` }} />
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ───────────────────────────────────────────────────────────────
+
 function ConvertPage() {
   const { t } = useTranslation();
   const { user, loading: authLoading } = useAuth();
-  const [docs, setDocs] = useState([]);
-  const [loadingDocs, setLoadingDocs] = useState(true);
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [previewUrl, setPreviewUrl] = useState(null);
+
+  const [docs,           setDocs]           = useState([]);
+  const [loadingDocs,    setLoadingDocs]    = useState(true);
+  const [selectedFile,   setSelectedFile]   = useState(null);   // preview
+  const [previewUrl,     setPreviewUrl]     = useState(null);
   const [uploadProgress, setUploadProgress] = useState(null);
-  const [converting, setConverting] = useState(new Set());
-  const pollRef = useRef(null);
+  const [converting,     setConverting]     = useState(new Set());
+
+  // ── New feature state ──
+  const [searchQuery,    setSearchQuery]    = useState("");
+  const [checkedFiles,   setCheckedFiles]   = useState(new Set()); // bulk select
+  const [sortKey,        setSortKey]        = useState("date");
+  const [sortDir,        setSortDir]        = useState("desc");
+  const [elapsedTimes,   setElapsedTimes]   = useState({});       // filename → seconds
+
+  const pollRef          = useRef(null);
+  const elapsedRef       = useRef(null);
+  const processingStart  = useRef({});                             // filename → Date.now()
+
+  // ── Data loading ────────────────────────────────────────────────────────
 
   const loadDocs = async () => {
     try {
       const data = await fetchDocuments();
       if (Array.isArray(data)) setDocs(data);
-    } catch {
-      toast.error(t("convert.errors.loadFailed"));
-    } finally {
-      setLoadingDocs(false);
-    }
+    } catch { toast.error(t("convert.errors.loadFailed")); }
+    finally { setLoadingDocs(false); }
   };
 
   useEffect(() => {
@@ -160,7 +181,8 @@ function ConvertPage() {
     else if (!authLoading && !user) setLoadingDocs(false);
   }, [authLoading, user]);
 
-  // Poll while any doc is processing
+  // ── Status polling ───────────────────────────────────────────────────────
+
   useEffect(() => {
     const hasProcessing = docs.some((d) => d.status === "processing");
     if (hasProcessing && !pollRef.current) {
@@ -171,29 +193,89 @@ function ConvertPage() {
           setDocs((prev) => {
             data.forEach((d) => {
               const old = prev.find((p) => p.filename === d.filename);
-              if (old?.status === "processing" && d.status === "done")
+              if (old?.status === "processing" && d.status === "done") {
                 toast.success(t("convert.toasts.done", { filename: d.filename }));
-              if (old?.status === "processing" && d.status === "failed")
+                delete processingStart.current[d.filename];
+              }
+              if (old?.status === "processing" && d.status === "failed") {
                 toast.error(t("convert.toasts.failed", { filename: d.filename }));
+                delete processingStart.current[d.filename];
+              }
             });
             return data;
           });
         } catch {}
       }, 3000);
     }
-    if (!hasProcessing && pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-    return () => {
-      if (pollRef.current && !hasProcessing) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-    };
+    if (!hasProcessing && pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    return () => { if (pollRef.current && !hasProcessing) { clearInterval(pollRef.current); pollRef.current = null; } };
   }, [docs]);
 
-  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
+  // ── Live elapsed timer ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    const processingDocs = docs.filter((d) => d.status === "processing");
+
+    // Record start time for newly-processing files
+    processingDocs.forEach((d) => {
+      if (!processingStart.current[d.filename])
+        processingStart.current[d.filename] = Date.now();
+    });
+
+    if (processingDocs.length > 0 && !elapsedRef.current) {
+      elapsedRef.current = setInterval(() => {
+        const now = Date.now();
+        setElapsedTimes(
+          Object.fromEntries(
+            Object.entries(processingStart.current).map(([name, start]) => [
+              name, Math.floor((now - start) / 1000),
+            ])
+          )
+        );
+      }, 1000);
+    }
+    if (processingDocs.length === 0 && elapsedRef.current) {
+      clearInterval(elapsedRef.current);
+      elapsedRef.current = null;
+      setElapsedTimes({});
+    }
+    return () => {};
+  }, [docs]);
+
+  useEffect(() => () => {
+    if (pollRef.current)   clearInterval(pollRef.current);
+    if (elapsedRef.current) clearInterval(elapsedRef.current);
+  }, []);
+
+  // ── Keyboard shortcut: U = open file picker ──────────────────────────────
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === "u" && !e.ctrlKey && !e.metaKey && !e.altKey &&
+          document.activeElement.tagName !== "INPUT" &&
+          document.activeElement.tagName !== "TEXTAREA") {
+        document.getElementById("hidden-file-trigger")?.click();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  // ── Sort toggle ──────────────────────────────────────────────────────────
+
+  const handleSort = (key) => {
+    if (sortKey === key) setSortDir((d) => d === "asc" ? "desc" : "asc");
+    else { setSortKey(key); setSortDir("asc"); }
+  };
+
+  // ── Filtered + sorted docs ───────────────────────────────────────────────
+
+  const filteredDocs = sortDocs(
+    docs.filter((d) => d.filename.toLowerCase().includes(searchQuery.toLowerCase())),
+    sortKey, sortDir
+  );
+
+  // ── Actions ──────────────────────────────────────────────────────────────
 
   const handleUpload = async (file) => {
     setUploadProgress({ filename: file.name, progress: 0 });
@@ -201,221 +283,320 @@ function ConvertPage() {
       await uploadDocument(file, (p) => setUploadProgress((prev) => ({ ...prev, progress: p })));
       toast.success(t("convert.toasts.uploaded", { filename: file.name }));
       await loadDocs();
-    } catch {
-      toast.error(t("convert.errors.uploadFailed"));
-    } finally {
-      setUploadProgress(null);
-    }
+    } catch { toast.error(t("convert.errors.uploadFailed")); }
+    finally { setUploadProgress(null); }
   };
 
   const handleConvert = async (filename) => {
     setConverting((prev) => new Set(prev).add(filename));
+    processingStart.current[filename] = Date.now();
     try {
       await convertDocument(filename);
-      setDocs((prev) =>
-        prev.map((d) => (d.filename === filename ? { ...d, status: "processing" } : d))
-      );
+      setDocs((prev) => prev.map((d) => d.filename === filename ? { ...d, status: "processing" } : d));
     } catch (err) {
       toast.error(err?.response?.data?.detail ?? t("convert.errors.convertFailed"));
+      delete processingStart.current[filename];
     } finally {
-      setConverting((prev) => {
-        const s = new Set(prev);
-        s.delete(filename);
-        return s;
-      });
+      setConverting((prev) => { const s = new Set(prev); s.delete(filename); return s; });
     }
   };
 
   const handleSelect = async (filename) => {
-    if (selectedFile === filename) {
-      setSelectedFile(null);
-      setPreviewUrl(null);
-      return;
-    }
+    if (selectedFile === filename) { setSelectedFile(null); setPreviewUrl(null); return; }
     if (previewUrl) URL.revokeObjectURL(previewUrl);
-    setSelectedFile(filename);
-    setPreviewUrl(null);
-    try {
-      const url = await getPreviewBlob(filename);
-      setPreviewUrl(url);
-    } catch {
-      toast.error(t("convert.errors.previewFailed"));
-    }
+    setSelectedFile(filename); setPreviewUrl(null);
+    try { setPreviewUrl(await getPreviewBlob(filename)); }
+    catch { toast.error(t("convert.errors.previewFailed")); }
   };
 
   const handleDelete = async (filename) => {
     try {
       await deleteDocument(filename);
       setDocs((prev) => prev.filter((d) => d.filename !== filename));
-      if (selectedFile === filename) {
-        if (previewUrl) URL.revokeObjectURL(previewUrl);
-        setSelectedFile(null);
-        setPreviewUrl(null);
-      }
+      setCheckedFiles((prev) => { const s = new Set(prev); s.delete(filename); return s; });
+      if (selectedFile === filename) { if (previewUrl) URL.revokeObjectURL(previewUrl); setSelectedFile(null); setPreviewUrl(null); }
       toast.success(t("convert.toasts.deleted"));
-    } catch {
-      toast.error(t("convert.errors.deleteFailed"));
-    }
+    } catch { toast.error(t("convert.errors.deleteFailed")); }
   };
+
+  // ── Bulk actions ──────────────────────────────────────────────────────────
+
+  const toggleCheck = (e, filename) => {
+    e.stopPropagation();
+    setCheckedFiles((prev) => {
+      const s = new Set(prev);
+      s.has(filename) ? s.delete(filename) : s.add(filename);
+      return s;
+    });
+  };
+
+  const toggleCheckAll = () => {
+    if (checkedFiles.size === filteredDocs.length) setCheckedFiles(new Set());
+    else setCheckedFiles(new Set(filteredDocs.map((d) => d.filename)));
+  };
+
+  const bulkConvert = async () => {
+    const targets = [...checkedFiles].filter((fn) => {
+      const doc = docs.find((d) => d.filename === fn);
+      return doc && (doc.status === "pending" || doc.status === "failed");
+    });
+    await Promise.all(targets.map((fn) => handleConvert(fn)));
+    setCheckedFiles(new Set());
+  };
+
+  const bulkDelete = async () => {
+    const targets = [...checkedFiles];
+    await Promise.all(targets.map((fn) => handleDelete(fn)));
+    setCheckedFiles(new Set());
+  };
+
+  const hasConvertable = [...checkedFiles].some((fn) => {
+    const doc = docs.find((d) => d.filename === fn);
+    return doc && (doc.status === "pending" || doc.status === "failed");
+  });
 
   if (authLoading) return null;
 
   return (
-    <div className="space-y-7">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">{t("convert.title")}</h1>
-        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">{t("convert.subtitle")}</p>
+    <div className="space-y-6 animate-fade-in">
+      {/* Hidden trigger for keyboard shortcut */}
+      <input id="hidden-file-trigger" type="file" accept="application/pdf" className="hidden"
+        onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])} />
+
+      {/* Page header */}
+      <div className="border-b border-zinc-200 dark:border-zinc-800 pb-5">
+        <h1 className="text-xl font-semibold tracking-tight">{t("convert.title")}</h1>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-0.5">{t("convert.subtitle")}</p>
       </div>
 
-      <Dropzone onFile={handleUpload} disabled={!!uploadProgress} />
+      {/* Main layout */}
+      <div className={`flex flex-col ${selectedFile ? "lg:flex-row lg:gap-6" : ""}`}>
 
-      {uploadProgress && (
-        <UploadProgress filename={uploadProgress.filename} progress={uploadProgress.progress} />
-      )}
+        {/* Left: upload + file list */}
+        <div className={`space-y-4 ${selectedFile ? "lg:w-[46%] lg:shrink-0" : "w-full"}`}>
 
-      <div className="glass-card rounded-2xl p-6 space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold">{t("convert.yourFiles")}</h2>
-          {!loadingDocs && docs.length > 0 && (
-            <p className="text-sm text-zinc-400 dark:text-zinc-500">
-              {t("convert.fileCount", { count: docs.length })}
-            </p>
-          )}
-        </div>
+          <Dropzone onFile={handleUpload} disabled={!!uploadProgress} />
+          {uploadProgress && <UploadProgress filename={uploadProgress.filename} progress={uploadProgress.progress} />}
 
-        {loadingDocs && (
-          <div className="space-y-2">
-            <SkeletonRow />
-            <SkeletonRow />
-            <SkeletonRow />
-          </div>
-        )}
-
-        {!loadingDocs && docs.length === 0 && !uploadProgress && (
-          <div className="py-12 flex flex-col items-center text-center">
-            <div className="w-14 h-14 rounded-2xl bg-indigo-500/10 flex items-center justify-center mb-4">
-              <FileText className="w-6 h-6 text-indigo-500 dark:text-indigo-400" />
+          {/* File table */}
+          <div>
+            {/* List header row: label + search */}
+            <div className="flex items-center justify-between gap-3 mb-3">
+              <p className="section-label">{t("convert.yourFiles")}{!loadingDocs && docs.length > 0 && ` (${docs.length})`}</p>
+              {docs.length > 0 && (
+                <div className="relative">
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-400 pointer-events-none" />
+                  <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Filter files…"
+                    className="field-input pl-7 py-1 text-xs w-44"
+                  />
+                  {searchQuery && (
+                    <button onClick={() => setSearchQuery("")}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors">
+                      <X className="w-3 h-3" />
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
-            <h3 className="text-sm font-semibold mb-1">{t("convert.empty.title")}</h3>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-xs leading-relaxed">
-              {t("convert.empty.body")}
-            </p>
-          </div>
-        )}
 
-        {!loadingDocs && docs.length > 0 && (
-          <ul className="space-y-1.5">
-            {docs.map((doc) => {
-              const isConverting = converting.has(doc.filename);
-              const isProcessing = doc.status === "processing";
-              const busy = isConverting || isProcessing;
-              return (
-                <li
-                  key={doc.filename}
-                  onClick={() => handleSelect(doc.filename)}
-                  className={[
-                    "group flex items-center justify-between gap-3 p-3 rounded-xl border cursor-pointer transition-all duration-150",
-                    selectedFile === doc.filename
-                      ? "border-indigo-200 dark:border-indigo-500/30 bg-indigo-50/60 dark:bg-indigo-500/5"
-                      : "border-zinc-100 dark:border-zinc-800 hover:border-zinc-200 dark:hover:border-zinc-700 hover:bg-zinc-50 dark:hover:bg-zinc-800/50",
-                  ].join(" ")}
-                >
-                  <div className="flex items-center gap-3 min-w-0 flex-1">
-                    <div
-                      className={[
-                        "w-8 h-8 rounded-xl flex items-center justify-center shrink-0 transition-colors",
-                        selectedFile === doc.filename
-                          ? "bg-indigo-500/15 text-indigo-500"
-                          : "bg-zinc-100 dark:bg-zinc-800 text-zinc-400 group-hover:text-indigo-400",
-                      ].join(" ")}
-                    >
-                      <FileText className="w-4 h-4" />
+            <div className="border border-zinc-200 dark:border-zinc-800">
+              {/* Column headers (sortable) */}
+              {!loadingDocs && docs.length > 0 && (
+                <div className="grid grid-cols-[1.5rem_1fr_auto_auto] gap-3 items-center px-4 py-2 bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
+                  <button onClick={toggleCheckAll} className="flex items-center justify-center text-zinc-300 dark:text-zinc-700 hover:text-indigo-500 transition-colors">
+                    {checkedFiles.size > 0 && checkedFiles.size === filteredDocs.length
+                      ? <CheckSquare className="w-3.5 h-3.5 text-indigo-500" />
+                      : <div className={`w-3.5 h-3.5 border ${checkedFiles.size > 0 ? "border-indigo-400 bg-indigo-50 dark:bg-indigo-500/10" : "border-zinc-300 dark:border-zinc-700"}`} />
+                    }
+                  </button>
+                  <SortHeader label="File"   colKey="name"   sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+                  <SortHeader label="Status" colKey="status" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+                  <SortHeader label="Date"   colKey="date"   sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+                </div>
+              )}
+
+              {loadingDocs && (
+                <>
+                  {[...Array(3)].map((_, i) => (
+                    <div key={i} className="flex items-center justify-between gap-3 px-4 py-3.5 border-b last:border-0 border-zinc-100 dark:border-zinc-800">
+                      <div className="flex items-center gap-2.5 flex-1 min-w-0">
+                        <div className="skel w-4 h-4 shrink-0" />
+                        <div className="skel h-3 flex-1 max-w-[200px]" />
+                      </div>
+                      <div className="flex gap-2">
+                        <div className="skel h-3 w-14" />
+                        <div className="skel h-6 w-16" />
+                      </div>
                     </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium truncate">{doc.filename}</p>
-                      <p className="text-xs text-zinc-400 dark:text-zinc-500">
-                        {(doc.size / 1024).toFixed(1)} KB ·{" "}
-                        {new Date(doc.last_modified * 1000).toLocaleDateString()}
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    className="flex items-center gap-1.5 shrink-0"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <StatusBadge status={doc.status} />
-                    {doc.status === "pending" && (
-                      <button
-                        onClick={() => handleConvert(doc.filename)}
-                        disabled={busy}
-                        className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white disabled:opacity-60 transition-colors"
+                  ))}
+                </>
+              )}
+
+              {!loadingDocs && docs.length === 0 && !uploadProgress && (
+                <div className="px-4 py-14 flex flex-col items-center text-center">
+                  <FileText className="w-7 h-7 text-zinc-300 dark:text-zinc-700 mb-3" />
+                  <p className="text-sm font-medium mb-1">{t("convert.empty.title")}</p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-xs leading-relaxed">
+                    {t("convert.empty.body")}
+                  </p>
+                </div>
+              )}
+
+              {!loadingDocs && filteredDocs.length === 0 && docs.length > 0 && (
+                <div className="px-4 py-10 text-center">
+                  <p className="text-sm text-zinc-400">No files match "{searchQuery}"</p>
+                  <button onClick={() => setSearchQuery("")} className="text-xs text-indigo-500 hover:underline mt-1">Clear filter</button>
+                </div>
+              )}
+
+              {!loadingDocs && filteredDocs.length > 0 && (
+                <ul>
+                  {filteredDocs.map((doc) => {
+                    const isConverting = converting.has(doc.filename);
+                    const busy        = isConverting || doc.status === "processing";
+                    const isSelected  = selectedFile === doc.filename;
+                    const isChecked   = checkedFiles.has(doc.filename);
+                    const elapsed     = elapsedTimes[doc.filename];
+
+                    return (
+                      <li
+                        key={doc.filename}
+                        onClick={() => handleSelect(doc.filename)}
+                        className={[
+                          "group flex items-center gap-3 px-4 py-3 border-b border-zinc-100 dark:border-zinc-800 last:border-0 cursor-pointer transition-colors",
+                          isSelected
+                            ? "bg-indigo-50/60 dark:bg-indigo-500/8 border-l-2 border-l-indigo-500 !pl-[14px]"
+                            : isChecked
+                            ? "bg-zinc-50 dark:bg-zinc-800/40"
+                            : "hover:bg-zinc-50/60 dark:hover:bg-zinc-900/40",
+                        ].join(" ")}
                       >
-                        {isConverting ? (
-                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                        ) : (
-                          <Zap className="w-3.5 h-3.5" />
-                        )}
-                        {t("convert.actions.convert")}
+                        {/* Checkbox */}
+                        <div onClick={(e) => toggleCheck(e, doc.filename)}
+                          className="shrink-0 flex items-center justify-center w-4 h-4 cursor-pointer">
+                          {isChecked
+                            ? <CheckSquare className="w-3.5 h-3.5 text-indigo-500" />
+                            : <div className="w-3.5 h-3.5 border border-zinc-300 dark:border-zinc-700 opacity-0 group-hover:opacity-100 transition-opacity" />
+                          }
+                        </div>
+
+                        {/* File info */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <FileText className={`w-3.5 h-3.5 shrink-0 ${isSelected ? "text-indigo-500" : "text-zinc-300 dark:text-zinc-600"}`} />
+                            <p className="text-sm truncate">{doc.filename}</p>
+                          </div>
+                          <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 ml-5">
+                            {(doc.size / 1024).toFixed(1)} KB
+                          </p>
+                        </div>
+
+                        {/* Status */}
+                        <div className="shrink-0">
+                          <StatusText status={doc.status} elapsed={elapsed} />
+                        </div>
+
+                        {/* Date */}
+                        <p className="text-xs text-zinc-400 dark:text-zinc-500 shrink-0 w-20 text-right tabular-nums">
+                          {new Date(doc.last_modified * 1000).toLocaleDateString()}
+                        </p>
+
+                        {/* Actions */}
+                        <div className="flex items-center gap-1.5 shrink-0" onClick={(e) => e.stopPropagation()}>
+                          {doc.status === "pending" && (
+                            <button onClick={() => handleConvert(doc.filename)} disabled={busy} className="btn-primary text-xs px-2.5 py-1 gap-1">
+                              {isConverting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
+                              {t("convert.actions.convert")}
+                            </button>
+                          )}
+                          {doc.status === "failed" && (
+                            <button onClick={() => handleConvert(doc.filename)} disabled={busy} className="btn-secondary text-xs px-2.5 py-1 gap-1">
+                              {isConverting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Zap className="w-3 h-3" />}
+                              {t("convert.actions.retry")}
+                            </button>
+                          )}
+                          {doc.status === "done" && (
+                            <button onClick={() => downloadDocument(doc.filename.replace(/\.pdf$/, ".docx"))}
+                              className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-500/30 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 transition-colors"
+                              style={{ borderRadius: 2 }}>
+                              <Download className="w-3 h-3" />
+                              {t("convert.actions.downloadPdf")}
+                            </button>
+                          )}
+                          <button onClick={() => handleDelete(doc.filename)}
+                            className="p-1 text-zinc-300 dark:text-zinc-700 hover:text-red-500 dark:hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100">
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              {/* ── Bulk action bar ── */}
+              {checkedFiles.size > 0 && (
+                <div className="flex items-center justify-between gap-3 px-4 py-2.5 bg-indigo-50 dark:bg-indigo-500/10 border-t border-indigo-200 dark:border-indigo-500/20 animate-fade-in">
+                  <span className="text-xs font-medium text-indigo-700 dark:text-indigo-300">
+                    {checkedFiles.size} selected
+                  </span>
+                  <div className="flex items-center gap-2">
+                    {hasConvertable && (
+                      <button onClick={bulkConvert} className="btn-primary text-xs px-3 py-1 gap-1">
+                        <Zap className="w-3 h-3" />
+                        Convert selected
                       </button>
                     )}
-                    {doc.status === "failed" && (
-                      <button
-                        onClick={() => handleConvert(doc.filename)}
-                        disabled={busy}
-                        className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-lg bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-600 dark:text-zinc-300 disabled:opacity-60 transition-colors"
-                      >
-                        {isConverting ? (
-                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                        ) : (
-                          <Zap className="w-3.5 h-3.5" />
-                        )}
-                        {t("convert.actions.retry")}
-                      </button>
-                    )}
-                    {doc.status === "done" && (
-                      <button
-                        onClick={() => downloadDocument(doc.filename.replace(/\.pdf$/, ".docx"))}
-                        className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-lg bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-500/20 transition-colors"
-                      >
-                        <Download className="w-3.5 h-3.5" />
-                        {t("convert.actions.downloadPdf")}
-                      </button>
-                    )}
-                    <button
-                      onClick={() => handleDelete(doc.filename)}
-                      className="p-1.5 rounded-lg text-zinc-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                    >
-                      <Trash2 className="w-3.5 h-3.5" />
+                    <button onClick={bulkDelete} className="btn-danger text-xs px-3 py-1 gap-1">
+                      <Trash2 className="w-3 h-3" />
+                      Delete selected
+                    </button>
+                    <button onClick={() => setCheckedFiles(new Set())}
+                      className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">
+                      Clear
                     </button>
                   </div>
-                </li>
-              );
-            })}
-          </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Right: PDF preview panel */}
+        {selectedFile && (
+          <div className="flex-1 min-w-0 animate-fade-in">
+            <div className="border border-zinc-200 dark:border-zinc-800">
+              <div className="flex items-center justify-between px-4 py-2.5 bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
+                <p className="text-xs font-medium truncate text-zinc-600 dark:text-zinc-300 max-w-[200px]">{selectedFile}</p>
+                <div className="flex items-center gap-3 shrink-0">
+                  <button onClick={() => downloadDocument(selectedFile)}
+                    className="text-xs text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 transition-colors">
+                    {t("convert.actions.downloadPdf")}
+                  </button>
+                  <button onClick={() => { setSelectedFile(null); setPreviewUrl(null); }}
+                    className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors">
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+              <div className="p-4">
+                {previewUrl ? (
+                  <PDFViewer fileUrl={previewUrl} />
+                ) : (
+                  <div className="py-16 flex items-center justify-center gap-2 text-sm text-zinc-400">
+                    <Loader2 className="w-4 h-4 animate-spin text-indigo-500" />
+                    {t("convert.previewLoading")}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
         )}
       </div>
-
-      {selectedFile && (
-        <div className="glass-card rounded-2xl p-6 space-y-3">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium truncate text-zinc-700 dark:text-zinc-300">{selectedFile}</p>
-            <button
-              onClick={() => downloadDocument(selectedFile)}
-              className="text-xs text-indigo-500 dark:text-indigo-400 hover:underline shrink-0 ltr:ml-4 rtl:mr-4 transition-colors"
-            >
-              {t("convert.actions.downloadPdf")}
-            </button>
-          </div>
-          {previewUrl ? (
-            <PDFViewer fileUrl={previewUrl} />
-          ) : (
-            <div className="p-10 flex items-center justify-center gap-2 text-sm text-zinc-400">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              {t("convert.previewLoading")}
-            </div>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -3,70 +3,17 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../auth/AuthContext";
 import { fetchDocuments } from "../api/docs";
-import { FileText, Loader2, CircleCheck, XCircle, ChevronRight } from "lucide-react";
+import { FileText, ArrowRight } from "lucide-react";
 
-function StatCard({ icon: Icon, label, value, colorClass }) {
-  return (
-    <div className="glass-card rounded-2xl p-5 flex items-center gap-4">
-      <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${colorClass}`}>
-        <Icon className="w-5 h-5" />
-      </div>
-      <div>
-        <p className="text-xs text-zinc-500 dark:text-zinc-400">{label}</p>
-        <p className="text-2xl font-bold tabular-nums">{value}</p>
-      </div>
-    </div>
-  );
-}
-
-function StatSkeleton() {
-  return (
-    <div className="glass-card rounded-2xl p-5 flex items-center gap-4">
-      <div className="w-10 h-10 rounded-xl bg-zinc-100 dark:bg-zinc-800 animate-pulse shrink-0" />
-      <div className="space-y-2 flex-1">
-        <div className="h-3 w-20 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-        <div className="h-6 w-10 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-      </div>
-    </div>
-  );
-}
-
-function RecentRow({ doc }) {
-  const STATUS = {
-    pending: "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400",
-    processing: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
-    done: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-    failed: "bg-red-500/10 text-red-600 dark:text-red-400",
-  };
-  return (
-    <li className="flex items-center gap-3 py-3 border-b border-zinc-100 dark:border-zinc-800 last:border-0">
-      <div className="w-8 h-8 rounded-xl bg-indigo-500/10 flex items-center justify-center shrink-0">
-        <FileText className="w-4 h-4 text-indigo-500 dark:text-indigo-400" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium truncate">{doc.filename}</p>
-        <p className="text-xs text-zinc-400 dark:text-zinc-500">
-          {new Date(doc.last_modified * 1000).toLocaleDateString()}
-        </p>
-      </div>
-      <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${STATUS[doc.status] ?? STATUS.pending}`}>
-        {doc.status}
-      </span>
-    </li>
-  );
-}
-
-function RecentRowSkeleton() {
-  return (
-    <li className="flex items-center gap-3 py-3 border-b border-zinc-100 dark:border-zinc-800 last:border-0">
-      <div className="w-8 h-8 rounded-xl bg-zinc-100 dark:bg-zinc-800 animate-pulse shrink-0" />
-      <div className="flex-1 space-y-1.5">
-        <div className="h-3.5 w-48 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-        <div className="h-2.5 w-24 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-      </div>
-      <div className="h-5 w-14 bg-zinc-100 dark:bg-zinc-800 rounded-full animate-pulse" />
-    </li>
-  );
+function StatusText({ status }) {
+  const { t } = useTranslation();
+  const cls = {
+    pending:    "status-pending",
+    processing: "status-processing",
+    done:       "status-done",
+    failed:     "status-failed",
+  }[status] ?? "status-pending";
+  return <span className={cls}>{t(`convert.status.${status}`, { defaultValue: status })}</span>;
 }
 
 function Dashboard() {
@@ -80,98 +27,128 @@ function Dashboard() {
       .catch(() => setDocs([]));
   }, []);
 
-  const loading = docs === null;
-  const total = docs?.length ?? 0;
+  const loading    = docs === null;
+  const total      = docs?.length ?? 0;
   const converting = docs?.filter((d) => d.status === "processing" || d.status === "pending").length ?? 0;
-  const converted = docs?.filter((d) => d.status === "done").length ?? 0;
-  const failed = docs?.filter((d) => d.status === "failed").length ?? 0;
-  const recent = docs ? [...docs].sort((a, b) => b.last_modified - a.last_modified).slice(0, 5) : [];
-  const firstName = user?.name?.split(" ")[0];
+  const converted  = docs?.filter((d) => d.status === "done").length ?? 0;
+  const failed     = docs?.filter((d) => d.status === "failed").length ?? 0;
+  const recent     = docs ? [...docs].sort((a, b) => b.last_modified - a.last_modified).slice(0, 5) : [];
+  const firstName  = user?.name?.split(" ")[0];
 
   return (
-    <div className="space-y-7">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">
+    <div className="space-y-8 animate-fade-in">
+
+      {/* Page header */}
+      <div className="border-b border-zinc-200 dark:border-zinc-800 pb-5">
+        <h1 className="text-xl font-semibold tracking-tight">
           {firstName ? t("dashboard.welcomeBack", { name: firstName }) : t("dashboard.title")}
         </h1>
-        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">{t("dashboard.subtitle")}</p>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-0.5">{t("dashboard.subtitle")}</p>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      {/* ── Stats: inline bar with dividers, not cards ── */}
+      <div>
+        <p className="section-label mb-4">{t("dashboard.overview") ?? "Overview"}</p>
         {loading ? (
-          <>
-            <StatSkeleton />
-            <StatSkeleton />
-            <StatSkeleton />
-            <StatSkeleton />
-          </>
+          <div className="grid grid-cols-4 divide-x divide-zinc-200 dark:divide-zinc-800 border border-zinc-200 dark:border-zinc-800">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="px-5 py-5 space-y-2">
+                <div className="skel h-7 w-10" />
+                <div className="skel h-3 w-16" />
+              </div>
+            ))}
+          </div>
         ) : (
-          <>
-            <StatCard icon={FileText} label={t("dashboard.stats.total")} value={total} colorClass="bg-indigo-500/10 text-indigo-500 dark:text-indigo-400" />
-            <StatCard icon={Loader2} label={t("dashboard.stats.converting")} value={converting} colorClass="bg-amber-500/10 text-amber-500 dark:text-amber-400" />
-            <StatCard icon={CircleCheck} label={t("dashboard.stats.converted")} value={converted} colorClass="bg-emerald-500/10 text-emerald-500 dark:text-emerald-400" />
-            <StatCard icon={XCircle} label={t("dashboard.stats.failed")} value={failed} colorClass="bg-red-500/10 text-red-500 dark:text-red-400" />
-          </>
+          <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-y sm:divide-y-0 divide-zinc-200 dark:divide-zinc-800 border border-zinc-200 dark:border-zinc-800">
+            {[
+              { value: total,      label: t("dashboard.stats.total"),      cls: "text-zinc-900 dark:text-zinc-100" },
+              { value: converting, label: t("dashboard.stats.converting"), cls: "text-indigo-500 dark:text-indigo-400" },
+              { value: converted,  label: t("dashboard.stats.converted"),  cls: "text-emerald-600 dark:text-emerald-400" },
+              { value: failed,     label: t("dashboard.stats.failed"),     cls: "text-red-500 dark:text-red-400" },
+            ].map(({ value, label, cls }) => (
+              <div key={label} className="px-5 py-5">
+                <p className={`text-3xl font-bold tabular-nums ${cls}`}>{value}</p>
+                <p className="section-label mt-1.5">{label}</p>
+              </div>
+            ))}
+          </div>
         )}
       </div>
 
-      <div className="glass-card rounded-2xl p-6">
-        <div className="flex items-center justify-between mb-5">
-          <h2 className="text-base font-semibold">{t("dashboard.recentConversions")}</h2>
-          <Link
-            to="/convert"
-            className="inline-flex items-center gap-1 text-xs font-medium text-indigo-500 dark:text-indigo-400 hover:underline"
+      {/* ── Recent conversions: table layout ── */}
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <p className="section-label">{t("dashboard.recentConversions")}</p>
+          <Link to="/convert"
+            className="inline-flex items-center gap-1 text-xs font-medium text-indigo-500 dark:text-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-300 transition-colors"
           >
             {t("dashboard.goToConvert")}
-            <ChevronRight className="w-3.5 h-3.5" />
+            <ArrowRight className="w-3 h-3 rtl:rotate-180" />
           </Link>
         </div>
 
-        {loading && (
-          <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
-            <RecentRowSkeleton />
-            <RecentRowSkeleton />
-            <RecentRowSkeleton />
-          </ul>
-        )}
-
-        {!loading && recent.length === 0 && (
-          <div className="py-10 flex flex-col items-center text-center">
-            <div className="w-12 h-12 rounded-2xl bg-indigo-500/10 flex items-center justify-center mb-4">
-              <FileText className="w-5 h-5 text-indigo-500 dark:text-indigo-400" />
-            </div>
-            <p className="text-sm font-medium mb-1">{t("dashboard.empty.title")}</p>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-xs leading-relaxed mb-4">
-              {t("dashboard.empty.body")}
-            </p>
-            <Link
-              to="/convert"
-              className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors"
-            >
-              {t("dashboard.empty.cta")}
-            </Link>
+        <div className="border border-zinc-200 dark:border-zinc-800">
+          {/* Table header */}
+          <div className="grid grid-cols-[1fr_auto_auto] gap-4 px-4 py-2 bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
+            <span className="section-label">File name</span>
+            <span className="section-label">Status</span>
+            <span className="section-label">Date</span>
           </div>
-        )}
 
-        {!loading && recent.length > 0 && (
-          <>
-            <ul>
-              {recent.map((doc) => (
-                <RecentRow key={doc.filename} doc={doc} />
+          {loading && (
+            <>
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="grid grid-cols-[1fr_auto_auto] gap-4 items-center px-4 py-3.5 border-b border-zinc-100 dark:border-zinc-800 last:border-0">
+                  <div className="flex items-center gap-2.5">
+                    <div className="skel w-4 h-4 shrink-0" />
+                    <div className="skel h-3 w-48" />
+                  </div>
+                  <div className="skel h-3 w-14" />
+                  <div className="skel h-3 w-20" />
+                </div>
               ))}
-            </ul>
-            {total > 5 && (
-              <div className="mt-4 text-center">
-                <Link
-                  to="/convert"
-                  className="text-xs text-indigo-500 dark:text-indigo-400 hover:underline"
+            </>
+          )}
+
+          {!loading && recent.length === 0 && (
+            <div className="px-4 py-14 flex flex-col items-center text-center">
+              <FileText className="w-8 h-8 text-zinc-300 dark:text-zinc-700 mb-3" />
+              <p className="text-sm font-medium mb-1">{t("dashboard.empty.title")}</p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-xs leading-relaxed mb-5">
+                {t("dashboard.empty.body")}
+              </p>
+              <Link to="/convert" className="btn-primary text-xs px-4 py-1.5">
+                {t("dashboard.empty.cta")}
+              </Link>
+            </div>
+          )}
+
+          {!loading && recent.length > 0 && (
+            <>
+              {recent.map((doc) => (
+                <div key={doc.filename}
+                  className="grid grid-cols-[1fr_auto_auto] gap-4 items-center px-4 py-3.5 border-b border-zinc-100 dark:border-zinc-800 last:border-0 hover:bg-zinc-50/60 dark:hover:bg-zinc-900/40 transition-colors"
                 >
-                  {t("dashboard.viewAll", { count: total })}
-                </Link>
-              </div>
-            )}
-          </>
-        )}
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <FileText className="w-3.5 h-3.5 text-zinc-300 dark:text-zinc-600 shrink-0" />
+                    <p className="text-sm truncate">{doc.filename}</p>
+                  </div>
+                  <StatusText status={doc.status} />
+                  <p className="text-xs text-zinc-400 dark:text-zinc-500 whitespace-nowrap">
+                    {new Date(doc.last_modified * 1000).toLocaleDateString()}
+                  </p>
+                </div>
+              ))}
+              {total > 5 && (
+                <div className="px-4 py-2.5 bg-zinc-50 dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800">
+                  <Link to="/convert" className="text-xs text-indigo-500 dark:text-indigo-400 hover:underline">
+                    {t("dashboard.viewAll", { count: total })}
+                  </Link>
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ForgotPasswordPage.jsx
+++ b/frontend/src/pages/ForgotPasswordPage.jsx
@@ -25,20 +25,17 @@ function ForgotPasswordPage() {
   if (sent) {
     return (
       <div className="text-center space-y-5">
-        <div className="w-14 h-14 rounded-2xl bg-indigo-500/10 flex items-center justify-center mx-auto">
-          <Mail className="w-7 h-7 text-indigo-500 dark:text-indigo-400" />
+        <div className="w-12 h-12 bg-accent-subtle flex items-center justify-center mx-auto" style={{ borderRadius: 2 }}>
+          <Mail className="w-6 h-6 text-accent" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">Check your inbox</h1>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-2 leading-relaxed">
-            If <span className="font-medium text-zinc-700 dark:text-zinc-300">{email}</span> is registered,
+          <h1 className="text-2xl font-bold tracking-tight">Check your inbox</h1>
+          <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+            If <span className="font-medium text-foreground">{email}</span> is registered,
             we sent a password reset link. Check your spam folder if you don't see it.
           </p>
         </div>
-        <Link
-          to="/login"
-          className="inline-block text-sm text-indigo-500 hover:text-indigo-600 font-medium transition-colors"
-        >
+        <Link to="/login" className="inline-block text-sm text-accent hover:text-accent-hover font-medium transition-colors">
           Back to sign in
         </Link>
       </div>
@@ -47,38 +44,32 @@ function ForgotPasswordPage() {
 
   return (
     <div className="space-y-6">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">Forgot password?</h1>
-        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Forgot password?</h1>
+        <p className="text-sm text-muted-foreground mt-1">
           Enter your email and we'll send you a reset link.
         </p>
       </div>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
+          <label className="block text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
             Email
           </label>
           <input
             type="email"
             required
             value={email}
+            placeholder="you@example.com"
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="field-input"
           />
         </div>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors disabled:opacity-60"
-        >
+        <button type="submit" disabled={loading} className="btn-primary w-full py-2.5 justify-center">
           {loading ? "Sending…" : "Send reset link"}
         </button>
       </form>
       <p className="text-center">
-        <Link
-          to="/login"
-          className="text-sm text-indigo-500 hover:text-indigo-600 font-medium transition-colors"
-        >
+        <Link to="/login" className="text-sm text-accent hover:text-accent-hover font-medium transition-colors">
           Back to sign in
         </Link>
       </p>

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,24 +1,16 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import {
-  AlignRight,
-  LayoutDashboard,
-  Zap,
-  Cloud,
-  ChevronRight,
-  Tag,
-  FileText,
-} from "lucide-react";
+import { AlignRight, LayoutDashboard, Zap, Cloud, ArrowRight, FileText } from "lucide-react";
 import Logo from "../assets/Logo.jsx";
 import LanguageToggle from "../components/ui/LanguageToggle";
 import DarkModeToggle from "../components/ui/DarkModeToggle";
 
 const FEATURES = [
-  { icon: AlignRight, key: "rtl" },
-  { icon: LayoutDashboard, key: "layout" },
-  { icon: Zap, key: "gpu" },
-  { icon: Cloud, key: "cloud" },
+  { icon: AlignRight,      key: "rtl",    num: "01" },
+  { icon: LayoutDashboard, key: "layout", num: "02" },
+  { icon: Zap,             key: "gpu",    num: "03" },
+  { icon: Cloud,           key: "cloud",  num: "04" },
 ];
 
 const STEPS = [
@@ -30,48 +22,34 @@ const STEPS = [
 function LandingNavbar({ openLogin, openRegister }) {
   const { t } = useTranslation();
   return (
-    <header className="fixed top-0 inset-x-0 z-50 h-14 glass border-b border-zinc-200/60 dark:border-zinc-800/60">
-      <div className="max-w-6xl mx-auto h-full grid grid-cols-2 sm:grid-cols-3 items-center px-5">
-        <div>
-          <Link to="/" className="flex items-center gap-2">
-            <Logo className="h-6 w-auto fill-zinc-900 dark:fill-white" />
-          </Link>
-        </div>
-        <nav className="hidden sm:flex justify-center">
-          <Link
-            to="/pricing"
-            className="px-3 py-1.5 text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-          >
-            {t("nav.pricing")}
-          </Link>
-        </nav>
-        <div className="flex justify-end items-center gap-1">
-          <LanguageToggle />
-          <DarkModeToggle />
-          {openLogin && (
-            <button
-              onClick={openLogin}
-              className="hidden sm:block px-3 py-1.5 text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-            >
-              {t("nav.signIn")}
-            </button>
-          )}
-          {openRegister && (
-            <>
-              <button
-                onClick={openRegister}
-                className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors"
-              >
+    <header className="fixed top-0 inset-x-0 z-50 h-12 bg-white/90 dark:bg-zinc-950/90 backdrop-blur-md border-b border-zinc-200 dark:border-zinc-800">
+      <div className="max-w-6xl mx-auto h-full flex items-center justify-between px-6">
+        <Link to="/" className="flex items-center gap-2">
+          <Logo className="h-5 w-auto fill-zinc-900 dark:fill-white" />
+        </Link>
+        <div className="flex items-center gap-4">
+          <nav className="hidden sm:flex items-center gap-5 text-sm text-zinc-500 dark:text-zinc-400">
+            <Link to="/pricing" className="hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors">
+              {t("nav.pricing")}
+            </Link>
+          </nav>
+          <div className="flex items-center gap-1">
+            <LanguageToggle />
+            <DarkModeToggle />
+          </div>
+          <div className="flex items-center gap-2">
+            {openLogin && (
+              <button onClick={openLogin}
+                className="hidden sm:block text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors">
+                {t("nav.signIn")}
+              </button>
+            )}
+            {openRegister && (
+              <button onClick={openRegister} className="btn-primary text-xs px-3 py-1.5">
                 {t("nav.getStarted")}
               </button>
-              <button
-                onClick={openRegister}
-                className="sm:hidden inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors"
-              >
-                {t("nav.start")}
-              </button>
-            </>
-          )}
+            )}
+          </div>
         </div>
       </div>
     </header>
@@ -82,146 +60,146 @@ function LandingPage({ openLogin, openRegister }) {
   const { t } = useTranslation();
 
   return (
-    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 font-sans">
+    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
       <LandingNavbar openLogin={openLogin} openRegister={openRegister} />
 
-      {/* Hero */}
-      <section className="relative pt-32 pb-24 px-4 overflow-hidden">
-        <div className="absolute inset-0 -z-10 hero-glow" />
-        <div className="absolute inset-0 -z-10 [background-image:linear-gradient(to_right,rgba(99,102,241,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(99,102,241,0.05)_1px,transparent_1px)] [background-size:64px_64px]" />
-        <div className="max-w-3xl mx-auto text-center">
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-500/10 border border-indigo-500/20 text-indigo-600 dark:text-indigo-400 text-xs font-medium mb-8">
-            <Tag className="w-3 h-3" />
-            {t("landing.badge")}
-          </div>
-          <h1 className="text-5xl sm:text-6xl lg:text-7xl font-extrabold leading-[1.08] tracking-tight mb-6">
-            {t("landing.heroTitle1")}{" "}
-            <span className="text-gradient">{t("landing.heroTitle2")}</span>
-            <br />
-            {t("landing.heroTitle3")}
-          </h1>
-          <p className="text-lg text-zinc-500 dark:text-zinc-400 max-w-xl mx-auto mb-10 leading-relaxed">
-            {t("landing.heroSubtitle")}
-          </p>
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-            <button
-              onClick={openRegister}
-              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors group"
-            >
-              {t("landing.heroCta")}
-              <ChevronRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5 rtl:rotate-180" />
-            </button>
-            <button
-              onClick={openLogin}
-              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/60 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
-            >
-              {t("landing.heroSignIn")}
-            </button>
-          </div>
-          <p className="text-xs text-zinc-400 dark:text-zinc-600 mt-4">{t("landing.heroNote")}</p>
-        </div>
+      {/* ── HERO: asymmetric split ── */}
+      <section className="pt-12 min-h-screen flex flex-col">
+        <div className="flex-1 max-w-6xl mx-auto w-full px-6 flex flex-col lg:flex-row">
 
-        {/* Dashboard mockup */}
-        <div className="mt-16 max-w-3xl mx-auto">
-          <div className="glass-card rounded-2xl shadow-xl shadow-indigo-500/5 dark:shadow-black/40 overflow-hidden">
-            <div className="flex items-center gap-1.5 px-4 py-3 border-b border-zinc-200/80 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60">
-              <div className="w-3 h-3 rounded-full bg-red-400" />
-              <div className="w-3 h-3 rounded-full bg-amber-400" />
-              <div className="w-3 h-3 rounded-full bg-emerald-400" />
-              <div className="flex-1 mx-4">
-                <div className="h-5 bg-zinc-200 dark:bg-zinc-700 rounded-md max-w-[220px] mx-auto" />
-              </div>
+          {/* Left column — text */}
+          <div className="flex flex-col justify-center py-20 lg:py-0 lg:w-[52%] lg:pr-16">
+            <div className="flex items-center gap-2 mb-8">
+              <div className="h-px w-8 bg-indigo-500" />
+              <span className="section-label text-indigo-500">{t("landing.badge")}</span>
             </div>
-            <div className="p-6 grid gap-4">
-              <div className="grid grid-cols-3 gap-4">
-                {[
-                  { label: "Total documents", val: "12", color: "bg-indigo-500/10" },
-                  { label: "Converting", val: "1", color: "bg-amber-500/10" },
-                  { label: "Converted", val: "10", color: "bg-emerald-500/10" },
-                ].map(({ label, val, color }) => (
-                  <div key={label} className="glass-card rounded-xl p-4 flex items-center gap-3">
-                    <div className={`w-8 h-8 rounded-lg ${color} shrink-0`} />
-                    <div>
-                      <div className="text-lg font-bold">{val}</div>
-                      <div className="text-[11px] text-zinc-400 leading-tight">{label}</div>
-                    </div>
+            <h1 className="text-5xl sm:text-6xl lg:text-7xl font-bold leading-[1.04] tracking-tight mb-8">
+              {t("landing.heroTitle1")}{" "}
+              <span className="text-indigo-500">{t("landing.heroTitle2")}</span>
+              <br />
+              {t("landing.heroTitle3")}
+            </h1>
+            <p className="text-base text-zinc-500 dark:text-zinc-400 leading-relaxed mb-10 max-w-md">
+              {t("landing.heroSubtitle")}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <button onClick={openRegister} className="btn-primary gap-2 px-6 py-2.5 text-sm group">
+                {t("landing.heroCta")}
+                <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5 rtl:rotate-180" />
+              </button>
+              <button onClick={openLogin} className="btn-secondary px-6 py-2.5 text-sm">
+                {t("landing.heroSignIn")}
+              </button>
+            </div>
+            <p className="text-xs text-zinc-400 dark:text-zinc-600 mt-4">{t("landing.heroNote")}</p>
+          </div>
+
+          {/* Right column — app preview panel */}
+          <div className="lg:w-[48%] flex items-center py-12 lg:py-20">
+            <div className="w-full">
+              {/* Thin top accent */}
+              <div className="h-0.5 w-full bg-indigo-500 mb-0" />
+              <div className="studio-card overflow-hidden shadow-xl shadow-zinc-200/60 dark:shadow-black/40">
+                {/* Mini toolbar */}
+                <div className="flex items-center gap-3 px-4 py-2.5 border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900">
+                  <div className="flex gap-1.5">
+                    <div className="w-2.5 h-2.5 rounded-full bg-zinc-300 dark:bg-zinc-600" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-zinc-300 dark:bg-zinc-600" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-zinc-300 dark:bg-zinc-600" />
                   </div>
-                ))}
-              </div>
-              <div className="glass-card rounded-xl p-4 space-y-2">
-                {[
-                  { name: "تقرير المالية 2024.pdf", status: "done", w: "w-56" },
-                  { name: "عقد الخدمات.pdf", status: "processing", w: "w-40" },
-                  { name: "السياسة العامة.pdf", status: "pending", w: "w-48" },
-                ].map(({ name, status, w }) => (
-                  <div
-                    key={name}
-                    className="flex items-center justify-between py-2 border-b border-zinc-100 dark:border-zinc-800 last:border-0"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-7 h-7 rounded-lg bg-indigo-500/10 flex items-center justify-center">
-                        <FileText className="w-3.5 h-3.5 text-indigo-400" />
+                  <div className="flex-1 h-4 bg-zinc-200 dark:bg-zinc-700 rounded-sm max-w-[160px]" />
+                  <div className="w-16 h-4 bg-indigo-100 dark:bg-indigo-500/20 rounded-sm" />
+                </div>
+                {/* Content area */}
+                <div className="p-4 space-y-3">
+                  {/* Stat row — inline, no big cards */}
+                  <div className="grid grid-cols-4 divide-x divide-zinc-100 dark:divide-zinc-800 border border-zinc-100 dark:border-zinc-800">
+                    {[
+                      { v: "12", l: "Total",     c: "text-zinc-900 dark:text-zinc-100" },
+                      { v: "1",  l: "Converting",c: "text-indigo-500" },
+                      { v: "10", l: "Done",      c: "text-emerald-600 dark:text-emerald-400" },
+                      { v: "1",  l: "Failed",    c: "text-red-500" },
+                    ].map(({ v, l, c }) => (
+                      <div key={l} className="px-3 py-2.5 text-center">
+                        <p className={`text-xl font-bold tabular-nums ${c}`}>{v}</p>
+                        <p className="text-[9px] text-zinc-400 uppercase tracking-wide mt-0.5">{l}</p>
                       </div>
-                      <div className={`h-3 ${w} bg-zinc-200 dark:bg-zinc-700 rounded`} />
-                    </div>
-                    <span
-                      className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                        status === "done"
-                          ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                          : status === "processing"
-                          ? "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400"
-                          : "bg-zinc-200/80 dark:bg-zinc-800 text-zinc-400"
-                      }`}
-                    >
-                      {status === "done" ? "Done" : status === "processing" ? "Converting" : "Pending"}
-                    </span>
+                    ))}
                   </div>
-                ))}
+                  {/* Column headers */}
+                  <div className="grid grid-cols-[1fr_auto_auto] gap-3 px-3 py-1.5 border-b border-zinc-100 dark:border-zinc-800">
+                    <span className="section-label">File</span>
+                    <span className="section-label">Status</span>
+                    <span className="section-label">Action</span>
+                  </div>
+                  {/* Rows */}
+                  {[
+                    { name: "تقرير المالية 2024.pdf", w: 140, status: "done",       statusCls: "status-done" },
+                    { name: "عقد الخدمات.pdf",         w: 110, status: "converting", statusCls: "status-processing" },
+                    { name: "السياسة العامة.pdf",       w: 125, status: "pending",   statusCls: "status-pending" },
+                  ].map(({ name, w, statusCls, status }, i) => (
+                    <div key={name} className="grid grid-cols-[1fr_auto_auto] gap-3 items-center px-3 py-2.5 border-b border-zinc-100 dark:border-zinc-800 last:border-0">
+                      <div className="flex items-center gap-2">
+                        <FileText className="w-3.5 h-3.5 text-zinc-300 dark:text-zinc-600 shrink-0" />
+                        <div className="h-2.5 rounded-sm bg-zinc-200 dark:bg-zinc-700" style={{ width: w }} />
+                      </div>
+                      <span className={statusCls}>{status}</span>
+                      <div className={`h-5 w-14 rounded-sm ${i === 0 ? 'bg-emerald-50 dark:bg-emerald-500/10' : i === 2 ? 'bg-indigo-50 dark:bg-indigo-500/10' : 'bg-zinc-100 dark:bg-zinc-800'}`} />
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Features */}
-      <section className="py-24 px-4 bg-zinc-50 dark:bg-zinc-900/40">
-        <div className="max-w-5xl mx-auto">
-          <div className="text-center mb-14">
-            <h2 className="text-3xl sm:text-4xl font-bold mb-4">{t("landing.featuresTitle")}</h2>
-            <p className="text-zinc-500 dark:text-zinc-400 max-w-lg mx-auto">
-              {t("landing.featuresSubtitle")}
-            </p>
+      {/* ── Full-width rule ── */}
+      <div className="border-t border-zinc-200 dark:border-zinc-800" />
+
+      {/* ── FEATURES: numbered editorial list ── */}
+      <section className="py-24 px-6">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex items-baseline gap-6 mb-12">
+            <span className="section-label">{t("landing.featuresTitle")}</span>
+            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
           </div>
-          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-            {FEATURES.map(({ icon: Icon, key }) => (
-              <div
-                key={key}
-                className="glass-card rounded-2xl p-5 hover:shadow-md hover:shadow-indigo-500/5 dark:hover:shadow-black/30 hover:border-indigo-200 dark:hover:border-indigo-500/20 transition-all duration-200 group"
-              >
-                <div className="w-9 h-9 rounded-xl bg-indigo-500/10 flex items-center justify-center mb-4 group-hover:bg-indigo-500/15 transition-colors">
-                  <Icon className="w-4 h-4 text-indigo-500 dark:text-indigo-400" />
+          <div className="grid gap-0 divide-y divide-zinc-100 dark:divide-zinc-800 border-t border-zinc-100 dark:border-zinc-800">
+            {FEATURES.map(({ icon: Icon, key, num }) => (
+              <div key={key}
+                className="grid grid-cols-[3rem_1fr_auto] sm:grid-cols-[4rem_1fr_1fr] items-start gap-6 py-8 group hover:bg-zinc-50/60 dark:hover:bg-zinc-900/40 px-2 -mx-2 transition-colors">
+                <span className="text-3xl font-bold text-zinc-100 dark:text-zinc-800 select-none group-hover:text-zinc-200 dark:group-hover:text-zinc-700 transition-colors tabular-nums">{num}</span>
+                <div>
+                  <h3 className="font-semibold text-base mb-1">{t(`landing.features.${key}.title`)}</h3>
+                  <p className="text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed sm:max-w-xs">
+                    {t(`landing.features.${key}.desc`)}
+                  </p>
                 </div>
-                <h3 className="font-semibold text-sm mb-2">{t(`landing.features.${key}.title`)}</h3>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">
-                  {t(`landing.features.${key}.desc`)}
-                </p>
+                <div className="hidden sm:flex justify-end">
+                  <div className="w-9 h-9 border border-zinc-200 dark:border-zinc-700 flex items-center justify-center group-hover:border-indigo-300 dark:group-hover:border-indigo-600 group-hover:bg-indigo-50 dark:group-hover:bg-indigo-500/10 transition-colors">
+                    <Icon className="w-4 h-4 text-zinc-400 group-hover:text-indigo-500 transition-colors" />
+                  </div>
+                </div>
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* How it works */}
-      <section className="py-24 px-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center mb-14">
-            <h2 className="text-3xl sm:text-4xl font-bold mb-4">{t("landing.howTitle")}</h2>
-            <p className="text-zinc-500 dark:text-zinc-400">{t("landing.howSubtitle")}</p>
+      {/* ── Full-width rule ── */}
+      <div className="border-t border-zinc-200 dark:border-zinc-800" />
+
+      {/* ── HOW IT WORKS: large numbers as typographic anchors ── */}
+      <section className="py-24 px-6">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex items-baseline gap-6 mb-12">
+            <span className="section-label">{t("landing.howTitle")}</span>
+            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
           </div>
-          <div className="grid gap-8 sm:grid-cols-3">
+          <div className="grid sm:grid-cols-3 gap-0 divide-y sm:divide-y-0 sm:divide-x divide-zinc-200 dark:divide-zinc-800">
             {STEPS.map(({ num, key }) => (
-              <div key={key} className="relative">
-                <div className="text-6xl font-black text-zinc-100 dark:text-zinc-800 select-none mb-4 leading-none">
+              <div key={key} className="py-8 sm:px-10 first:sm:pl-0 last:sm:pr-0">
+                <div className="text-[4.5rem] font-extrabold leading-none text-zinc-100 dark:text-zinc-800/80 select-none mb-6 tabular-nums">
                   {num}
                 </div>
                 <h3 className="font-semibold mb-2">{t(`landing.steps.${key}.title`)}</h3>
@@ -234,49 +212,43 @@ function LandingPage({ openLogin, openRegister }) {
         </div>
       </section>
 
-      {/* CTA */}
-      <section className="py-24 px-4">
-        <div className="max-w-2xl mx-auto text-center">
-          <div className="glass-card rounded-3xl p-12 relative overflow-hidden">
-            <div className="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-500/5 via-transparent to-violet-500/5" />
-            <h2 className="text-3xl sm:text-4xl font-bold mb-4">{t("landing.ctaTitle")}</h2>
-            <p className="text-zinc-500 dark:text-zinc-400 mb-8 max-w-sm mx-auto">
+      {/* ── CTA: full-width dark band ── */}
+      <section className="bg-zinc-950 dark:bg-black py-20 px-6">
+        <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between gap-8">
+          <div>
+            <h2 className="text-3xl sm:text-4xl font-bold text-white leading-tight mb-3">
+              {t("landing.ctaTitle")}
+            </h2>
+            <p className="text-zinc-400 max-w-sm leading-relaxed text-sm">
               {t("landing.ctaSubtitle")}
             </p>
-            <button
-              onClick={openRegister}
-              className="inline-flex items-center gap-2 px-6 py-3 text-base font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors group"
-            >
+          </div>
+          <div className="shrink-0">
+            <button onClick={openRegister} className="btn-primary px-8 py-3 text-base gap-2 group">
               {t("landing.ctaButton")}
-              <ChevronRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5 rtl:rotate-180" />
+              <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5 rtl:rotate-180" />
             </button>
           </div>
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="border-t border-zinc-200 dark:border-zinc-800 py-8 px-4">
+      {/* ── Footer ── */}
+      <footer className="border-t border-zinc-200 dark:border-zinc-800 py-6 px-6">
         <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
-          <div className="flex items-center gap-2">
-            <Logo className="h-5 w-auto fill-zinc-400 dark:fill-zinc-600" />
-            <span className="text-sm text-zinc-400 dark:text-zinc-600">
+          <div className="flex items-center gap-3">
+            <Logo className="h-4 w-auto fill-zinc-400 dark:fill-zinc-600" />
+            <span className="text-xs text-zinc-400 dark:text-zinc-600">
               {t("landing.footerCopy", { year: new Date().getFullYear() })}
             </span>
           </div>
-          <div className="flex items-center gap-5 text-sm text-zinc-400 dark:text-zinc-600">
+          <div className="flex items-center gap-5 text-xs text-zinc-400 dark:text-zinc-600">
             <Link to="/pricing" className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors">
               {t("nav.pricing")}
             </Link>
-            <button
-              onClick={openLogin}
-              className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
-            >
+            <button onClick={openLogin} className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors">
               {t("nav.signIn")}
             </button>
-            <button
-              onClick={openRegister}
-              className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
-            >
+            <button onClick={openRegister} className="text-indigo-500 hover:text-indigo-600 transition-colors font-medium">
               {t("nav.getStarted")}
             </button>
           </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -42,59 +42,48 @@ function LoginPage() {
 
   return (
     <div className="space-y-6">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{t("auth.login.title")}</h1>
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{t("auth.login.title")}</h1>
         <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">{t("auth.login.subtitle")}</p>
       </div>
+
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
+          <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
             {t("auth.login.email")}
           </label>
-          <input
-            type="email"
-            required
-            value={form.email}
+          <input type="email" required value={form.email} placeholder="you@example.com"
             onChange={(e) => setForm({ ...form, email: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+            className="field-input" />
         </div>
         <div>
           <div className="flex items-center justify-between mb-1.5">
-            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
               {t("auth.login.password")}
             </label>
-            <Link
-              to="/forgot-password"
-              className="text-xs text-indigo-500 dark:text-indigo-400 hover:underline"
-            >
+            <Link to="/forgot-password" className="text-xs text-indigo-500 hover:text-indigo-600 transition-colors">
               {t("auth.login.forgotPassword")}
             </Link>
           </div>
-          <input
-            type="password"
-            required
-            value={form.password}
+          <input type="password" required value={form.password}
             onChange={(e) => setForm({ ...form, password: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+            className="field-input" />
         </div>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors disabled:opacity-60"
-        >
+        <button type="submit" disabled={loading} className="btn-primary w-full py-2.5 justify-center">
           {loading ? t("auth.login.submitting") : t("auth.login.submit")}
         </button>
       </form>
-      <div className="relative flex items-center gap-3">
-        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-700" />
+
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
         <span className="text-xs text-zinc-400">{t("auth.signup.orContinueWith")}</span>
-        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-700" />
+        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
       </div>
+
       <div className="flex justify-center">
         <GoogleLogin onSuccess={handleGoogle} onError={() => toast.error("Google sign-in failed.")} />
       </div>
+
       <p className="text-center text-sm text-zinc-500 dark:text-zinc-400">
         {t("auth.login.noAccount")}{" "}
         <Link to="/signup" className="text-indigo-500 hover:text-indigo-600 font-medium transition-colors">

--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -3,17 +3,14 @@ import { useNavigate } from "react-router-dom";
 
 function NotFound() {
   const navigate = useNavigate();
-
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center">
-      <h1 className="text-5xl font-bold text-red-600 mb-4">404</h1>
-      <p className="text-lg text-gray-700 mb-6">Page Not Found</p>
-      <button
-        onClick={() => navigate("/")}
-        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-      >
-        Go Home
-      </button>
+    <div className="min-h-screen bg-white dark:bg-zinc-950 flex flex-col items-center justify-center text-center px-4">
+      <div className="text-[9rem] font-extrabold leading-none text-zinc-100 dark:text-zinc-900 select-none tabular-nums mb-6">
+        404
+      </div>
+      <h1 className="text-xl font-semibold mb-2">Page not found</h1>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-8">The page you're looking for doesn't exist.</p>
+      <button onClick={() => navigate("/")} className="btn-primary px-6 py-2">Go Home</button>
     </div>
   );
 }

--- a/frontend/src/pages/PricingPage.jsx
+++ b/frontend/src/pages/PricingPage.jsx
@@ -1,40 +1,68 @@
-// src/pages/PricingPage.jsx
 import React from "react";
+import { Link } from "react-router-dom";
+import { Check } from "lucide-react";
+
+const PLANS = [
+  {
+    name: "Free",
+    price: "$0",
+    desc: "Perfect for light use",
+    features: ["5 pages per PDF", "Basic layout detection", "Community support"],
+    cta: "Get Started",
+    href: "/signup",
+    accent: false,
+  },
+  {
+    name: "Pro",
+    price: "$9.99",
+    period: "/mo",
+    desc: "Ideal for frequent users",
+    features: ["50+ pages per PDF", "Advanced layout detection", "Priority processing", "Translation (Soon)"],
+    cta: "Upgrade",
+    href: "/coming-soon",
+    accent: true,
+  },
+];
 
 export default function PricingPage() {
   return (
-    <div className="min-h-screen bg-secondary p-6 flex flex-col items-center text-center">
-      <h1 className="heading mb-4">Choose Your Plan</h1>
-      <p className="text-muted mb-10 max-w-xl">
-        Whether you’re an occasional user or a document-heavy pro, TextAra has a plan for you.
-      </p>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl w-full">
-        {/* Free Plan */}
-        <div className="card">
-          <h2 className="text-xl font-bold mb-2 text-primary">Free</h2>
-          <p className="text-muted mb-4">Perfect for light use</p>
-          <ul className="list-disc list-inside text-left mb-4 text-gray-700 space-y-1">
-            <li>5 pages per PDF</li>
-            <li>Basic layout detection</li>
-            <li>Community support</li>
-          </ul>
-          <p className="text-2xl font-bold mb-4">$0</p>
-          <a href="/register" className="btn-primary w-full block text-center">Get Started</a>
+    <div className="min-h-screen bg-white dark:bg-zinc-950">
+      <div className="max-w-4xl mx-auto px-6 py-20">
+        <div className="mb-14">
+          <div className="flex items-baseline gap-4 mb-6">
+            <span className="section-label">Pricing</span>
+            <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
+          </div>
+          <h1 className="text-4xl font-bold tracking-tight mb-3 text-foreground">Choose your plan</h1>
+          <p className="text-zinc-500 dark:text-zinc-400 text-sm max-w-md">
+            Whether you're an occasional user or a document-heavy professional.
+          </p>
         </div>
 
-        {/* Pro Plan */}
-        <div className="card border-2 border-primary">
-          <h2 className="text-xl font-bold mb-2 text-primary">Pro</h2>
-          <p className="text-muted mb-4">Ideal for frequent users</p>
-          <ul className="list-disc list-inside text-left mb-4 text-gray-700 space-y-1">
-            <li>50+ pages per PDF</li>
-            <li>Advanced layout detection</li>
-            <li>Priority processing</li>
-            <li>Translation support (Coming Soon)</li>
-          </ul>
-          <p className="text-2xl font-bold mb-4">$9.99 / month</p>
-          <a href="/coming-soon" className="btn-secondary w-full block text-center">Upgrade</a>
+        <div className="grid sm:grid-cols-2 gap-0 border border-zinc-200 dark:border-zinc-800 divide-y sm:divide-y-0 sm:divide-x divide-zinc-200 dark:divide-zinc-800">
+          {PLANS.map((plan) => (
+            <div key={plan.name} className={`p-8 flex flex-col bg-surface ${plan.accent ? "border-t-2 border-t-indigo-500" : "border-t-2 border-t-zinc-200 dark:border-t-zinc-700"}`}>
+              <div className="mb-6">
+                <h2 className="text-lg font-bold mb-1 text-foreground">{plan.name}</h2>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">{plan.desc}</p>
+              </div>
+              <div className="mb-8">
+                <span className="text-4xl font-extrabold tabular-nums text-foreground">{plan.price}</span>
+                {plan.period && <span className="text-sm text-zinc-400 ml-1">{plan.period}</span>}
+              </div>
+              <ul className="space-y-3 mb-8 flex-1">
+                {plan.features.map((f) => (
+                  <li key={f} className="flex items-start gap-2.5 text-sm text-zinc-600 dark:text-zinc-400">
+                    <Check className="w-3.5 h-3.5 shrink-0 mt-0.5 text-indigo-500" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+              <Link to={plan.href} className={plan.accent ? "btn-primary justify-center py-2.5" : "btn-secondary justify-center py-2.5"}>
+                {plan.cta}
+              </Link>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -1,26 +1,32 @@
 import React, { useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
+import { Eye, EyeOff, CheckCircle } from "lucide-react";
 import toast from "react-hot-toast";
 import { resetPassword } from "../features/auth/authservice";
+
+const PASSWORD_RULES = [
+  { key: "minLength", label: "At least 8 characters",        test: (p) => p.length >= 8 },
+  { key: "uppercase", label: "One uppercase letter (A–Z)",   test: (p) => /[A-Z]/.test(p) },
+  { key: "number",    label: "One number (0–9)",             test: (p) => /[0-9]/.test(p) },
+  { key: "special",   label: "One special character (!@#…)", test: (p) => /[^A-Za-z0-9]/.test(p) },
+];
 
 function ResetPasswordPage() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token") ?? "";
   const [form, setForm] = useState({ new_password: "", confirm: "" });
+  const [showPass, setShowPass] = useState(false);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
 
   if (!token) {
     return (
       <div className="text-center space-y-4">
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">Invalid link</h1>
-        <p className="text-zinc-500 dark:text-zinc-400 text-sm">
+        <h1 className="text-2xl font-bold tracking-tight">Invalid link</h1>
+        <p className="text-sm text-muted-foreground">
           This password reset link is missing a token.
         </p>
-        <Link
-          to="/forgot-password"
-          className="text-sm text-indigo-500 hover:text-indigo-600 transition-colors"
-        >
+        <Link to="/forgot-password" className="text-sm text-accent hover:text-accent-hover transition-colors">
           Request a new link
         </Link>
       </div>
@@ -29,16 +35,17 @@ function ResetPasswordPage() {
 
   if (done) {
     return (
-      <div className="text-center space-y-4">
-        <div className="text-5xl">✅</div>
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">Password updated</h1>
-        <p className="text-sm text-zinc-500 dark:text-zinc-400">
-          Your password has been changed successfully.
-        </p>
-        <Link
-          to="/login"
-          className="inline-block text-sm font-medium text-indigo-500 hover:text-indigo-600 transition-colors"
-        >
+      <div className="text-center space-y-5">
+        <div className="w-12 h-12 bg-success-subtle flex items-center justify-center mx-auto" style={{ borderRadius: 2 }}>
+          <CheckCircle className="w-6 h-6 text-success" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Password updated</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Your password has been changed successfully.
+          </p>
+        </div>
+        <Link to="/login" className="inline-block text-sm font-medium text-accent hover:text-accent-hover transition-colors">
           Sign in
         </Link>
       </div>
@@ -47,6 +54,11 @@ function ResetPasswordPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    const allPass = PASSWORD_RULES.every((r) => r.test(form.new_password));
+    if (!allPass) {
+      toast.error("Password doesn't meet the requirements.");
+      return;
+    }
     if (form.new_password !== form.confirm) {
       toast.error("Passwords do not match.");
       return;
@@ -62,29 +74,58 @@ function ResetPasswordPage() {
     }
   };
 
+  const passRules = PASSWORD_RULES.map((r) => ({ ...r, ok: r.test(form.new_password) }));
+  const strength = passRules.filter((r) => r.ok).length;
+  const strengthColor = ["bg-error", "bg-warning", "bg-warning", "bg-success", "bg-success"][strength];
+
   return (
     <div className="space-y-6">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">Set new password</h1>
-        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Set new password</h1>
+        <p className="text-sm text-muted-foreground mt-1">
           Choose a strong password for your account.
         </p>
       </div>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
+          <label className="block text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
             New password
           </label>
-          <input
-            type="password"
-            required
-            value={form.new_password}
-            onChange={(e) => setForm({ ...form, new_password: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+          <div className="relative">
+            <input
+              type={showPass ? "text" : "password"}
+              required
+              value={form.new_password}
+              onChange={(e) => setForm({ ...form, new_password: e.target.value })}
+              className="field-input pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPass(!showPass)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-muted-foreground transition-colors"
+            >
+              {showPass ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
+          {form.new_password && (
+            <div className="mt-2 space-y-1.5">
+              <div className="flex gap-1 h-1">
+                {[0, 1, 2, 3].map((i) => (
+                  <div key={i} className={`flex-1 transition-colors ${i < strength ? strengthColor : "bg-muted"}`} style={{ borderRadius: 1 }} />
+                ))}
+              </div>
+              <ul className="grid grid-cols-2 gap-x-3 gap-y-0.5">
+                {passRules.map((r) => (
+                  <li key={r.key} className={`text-[11px] flex items-center gap-1 ${r.ok ? "text-success" : "text-subtle"}`}>
+                    <span>{r.ok ? "✓" : "·"}</span>{r.label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
+          <label className="block text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
             Confirm password
           </label>
           <input
@@ -92,14 +133,13 @@ function ResetPasswordPage() {
             required
             value={form.confirm}
             onChange={(e) => setForm({ ...form, confirm: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="field-input"
           />
+          {form.confirm && form.confirm !== form.new_password && (
+            <p className="text-[11px] text-error mt-1">Passwords do not match.</p>
+          )}
         </div>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors disabled:opacity-60"
-        >
+        <button type="submit" disabled={loading} className="btn-primary w-full py-2.5 justify-center">
           {loading ? "Updating…" : "Update password"}
         </button>
       </form>

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import Button from "../components/ui/Button";
 import { useAuth } from "../auth/AuthContext";
 import { updateCurrentUser } from "../features/auth/authservice";
 
@@ -13,65 +12,65 @@ function SettingsPage() {
   const handleSave = async () => {
     setLoading(true);
     setStatus("");
-
     const token = localStorage.getItem("access_token");
     try {
       await updateCurrentUser(token, { name });
-      await login(token); // refresh context with updated user
-      setStatus("Changes saved successfully.");
-    } catch (err) {
-      console.error("Failed to update user:", err);
-      setStatus("Failed to update. Please try again.");
+      await login(token);
+      setStatus("saved");
+    } catch {
+      setStatus("error");
     } finally {
       setLoading(false);
     }
   };
 
-  const resendVerification = () => {
-    // Placeholder — to be implemented later
-    console.log("Resending verification email");
-    setStatus("Verification email sent.");
-  };
+  const resendVerification = () => setStatus("verification_sent");
 
   return (
-    <div className="space-y-8">
-      <h1 className="text-3xl font-bold text-content">Settings</h1>
+    <div className="space-y-6 animate-fade-in max-w-lg">
+      <div className="border-b border-zinc-200 dark:border-zinc-800 pb-5">
+        <h1 className="text-xl font-semibold tracking-tight">Settings</h1>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-0.5">Manage your account</p>
+      </div>
 
-      <div className="bg-background dark:bg-primary-light text-content dark:text-content-light rounded-lg shadow p-6 space-y-4">
-        <div>
-          <label className="block font-semibold text-content mb-1">Name</label>
-          <input
-            type="text"
-            className="w-full border border-content-muted dark:border-content-dark bg-background dark:bg-background-dark text-content dark:text-content-light rounded px-3 py-2"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
+      <div className="border border-zinc-200 dark:border-zinc-800 border-t-2 border-t-indigo-500">
+        <div className="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800">
+          <p className="section-label">Profile</p>
         </div>
-
-        <div>
-          <label className="block font-semibold mb-1">Email</label>
-          <input
-            type="email"
-            value={email}
-            className="w-full border border-gray-200 bg-gray-100 rounded px-3 py-2"
-            disabled
-          />
-        </div>
-
-        {!user?.is_verified && (
-          <div className="text-yellow-700 dark:text-yellow-400 text-sm">
-            Your email is not verified.{" "}
-            <button onClick={resendVerification} className="underline text-secondary">
-              Resend verification email
-            </button>
+        <div className="px-5 py-5 space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+              Name
+            </label>
+            <input type="text" className="field-input" value={name} onChange={(e) => setName(e.target.value)} />
           </div>
-        )}
+          <div>
+            <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+              Email
+            </label>
+            <input type="email" value={email} className="field-input opacity-50 cursor-not-allowed" disabled />
+          </div>
 
-        <div className="flex items-center gap-4">
-          <Button variant="primary" onClick={handleSave} disabled={loading}>
-            {loading ? "Saving..." : "Save Changes"}
-          </Button>
-          {status && <p className="text-sm text-content-muted">{status}</p>}
+          {!user?.is_verified && (
+            <div className="flex items-start gap-2 px-3 py-2.5 bg-amber-50 dark:bg-amber-500/5 border border-amber-200 dark:border-amber-500/20 text-sm">
+              <span className="text-amber-500 mt-0.5">⚠</span>
+              <span className="text-amber-700 dark:text-amber-400">
+                Email not verified.{" "}
+                <button onClick={resendVerification} className="underline text-indigo-500 hover:text-indigo-600">
+                  Resend verification email
+                </button>
+              </span>
+            </div>
+          )}
+
+          <div className="flex items-center gap-3 pt-1">
+            <button onClick={handleSave} disabled={loading} className="btn-primary px-5 py-2">
+              {loading ? "Saving…" : "Save Changes"}
+            </button>
+            {status === "saved" && <p className="text-xs text-emerald-600 dark:text-emerald-400">Saved successfully.</p>}
+            {status === "error" && <p className="text-xs text-red-500">Failed to update. Please try again.</p>}
+            {status === "verification_sent" && <p className="text-xs text-indigo-500">Verification email sent.</p>}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -3,68 +3,111 @@ import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { GoogleLogin } from "@react-oauth/google";
 import toast from "react-hot-toast";
+import { Check, X, Eye, EyeOff } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 import { registerUser, googleAuth } from "../features/auth/authservice";
 
-const passwordRules = () => [
-  { key: "minLength", test: (p) => p.length >= 8 },
-  { key: "uppercase", test: (p) => /[A-Z]/.test(p) },
-  { key: "number", test: (p) => /[0-9]/.test(p) },
-  { key: "special", test: (p) => /[^A-Za-z0-9]/.test(p) },
+// ── Validation rules ────────────────────────────────────────────────────────
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+const PASSWORD_RULES = [
+  { key: "minLength", label: "At least 8 characters",           test: (p) => p.length >= 8 },
+  { key: "uppercase", label: "One uppercase letter (A–Z)",      test: (p) => /[A-Z]/.test(p) },
+  { key: "number",    label: "One number (0–9)",                test: (p) => /[0-9]/.test(p) },
+  { key: "special",   label: "One special character (!@#…)",    test: (p) => /[^A-Za-z0-9]/.test(p) },
 ];
 
-const isValidPassword = (p) => passwordRules().every((r) => r.test(p));
+function isStrongPassword(p) { return PASSWORD_RULES.every((r) => r.test(p)); }
 
-function PasswordStrength({ password }) {
-  const { t } = useTranslation();
-  const rules = passwordRules();
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function FieldError({ msg }) {
+  if (!msg) return null;
+  return <p className="mt-1 text-xs text-red-500 flex items-center gap-1"><X className="w-3 h-3 shrink-0" />{msg}</p>;
+}
+
+function PasswordStrengthMeter({ password }) {
   if (!password) return null;
+  const passed = PASSWORD_RULES.filter((r) => r.test(password)).length;
+  const pct    = (passed / PASSWORD_RULES.length) * 100;
 
-  const passed = rules.filter((r) => r.test(password)).length;
-  const pct = (passed / rules.length) * 100;
-  const barColor =
-    pct <= 25 ? "bg-red-500" : pct <= 50 ? "bg-amber-500" : pct <= 75 ? "bg-yellow-400" : "bg-emerald-500";
+  const [barColor, label] =
+    pct <= 25  ? ["bg-red-500",    "Weak"]       :
+    pct <= 50  ? ["bg-amber-500",  "Fair"]       :
+    pct <= 75  ? ["bg-yellow-400", "Good"]       :
+                 ["bg-emerald-500","Strong"];
 
   return (
     <div className="mt-2 space-y-2">
-      <div className="h-1 w-full bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden">
-        <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+      {/* Bar */}
+      <div className="flex items-center gap-2">
+        <div className="flex-1 h-0.5 bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
+          <div className={`h-full transition-all duration-300 ${barColor}`} style={{ width: `${pct}%` }} />
+        </div>
+        <span className="text-[10px] font-semibold" style={{ color: pct === 100 ? "#10b981" : undefined }}>{label}</span>
       </div>
-      <ul className="grid grid-cols-2 gap-x-3 gap-y-1">
-        {rules.map((r) => (
-          <li
-            key={r.key}
-            className={`text-[11px] flex items-center gap-1 ${
-              r.test(password) ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-400 dark:text-zinc-500"
-            }`}
-          >
-            <span>{r.test(password) ? "✓" : "·"}</span>
-            {t(`auth.password.${r.key}`)}
-          </li>
-        ))}
+      {/* Rule checklist */}
+      <ul className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+        {PASSWORD_RULES.map((r) => {
+          const ok = r.test(password);
+          return (
+            <li key={r.key} className={`text-[11px] flex items-center gap-1.5 transition-colors ${ok ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-400 dark:text-zinc-500"}`}>
+              {ok
+                ? <Check className="w-3 h-3 shrink-0" />
+                : <div className="w-3 h-3 shrink-0 border border-current rounded-full opacity-40" />
+              }
+              {r.label}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );
 }
 
+// ── Main page ───────────────────────────────────────────────────────────────
+
 function SignupPage() {
   const { t } = useTranslation();
   const { login } = useAuth();
   const navigate = useNavigate();
+
   const [form, setForm] = useState({ name: "", email: "", password: "", confirm: "" });
-  const [loading, setLoading] = useState(false);
-  const [registered, setRegistered] = useState(false);
+  const [touched, setTouched] = useState({});           // which fields have been blurred
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm,  setShowConfirm]  = useState(false);
+  const [loading,      setLoading]      = useState(false);
+  const [registered,   setRegistered]   = useState(false);
+
+  // ── Inline validation ───────────────────────────────────────────────────
+
+  const errors = {
+    name:     !form.name.trim()                        ? "Name is required."         : "",
+    email:    !form.email.trim()                       ? "Email is required."        :
+              !EMAIL_RE.test(form.email)               ? "Enter a valid email address." : "",
+    password: !form.password                           ? "Password is required."     :
+              !isStrongPassword(form.password)         ? "Password doesn't meet all requirements." : "",
+    confirm:  !form.confirm                            ? "Please confirm your password." :
+              form.confirm !== form.password           ? "Passwords don't match."    : "",
+  };
+
+  const isFormValid = Object.values(errors).every((e) => !e);
+
+  const blur  = (field) => setTouched((t) => ({ ...t, [field]: true }));
+  const show  = (field) => touched[field] && errors[field];
+
+  // ── Handlers ────────────────────────────────────────────────────────────
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!isValidPassword(form.password)) return;
-    if (form.password !== form.confirm) {
-      toast.error(t("auth.password.mismatch"));
-      return;
-    }
+    // Mark all fields touched so errors show on submit
+    setTouched({ name: true, email: true, password: true, confirm: true });
+    if (!isFormValid) return;
+
     setLoading(true);
     try {
-      await registerUser({ name: form.name, email: form.email, password: form.password });
+      await registerUser({ name: form.name.trim(), email: form.email.trim().toLowerCase(), password: form.password });
       setRegistered(true);
     } catch (err) {
       toast.error(err?.response?.data?.detail || "Registration failed. Please try again.");
@@ -86,105 +129,144 @@ function SignupPage() {
     }
   };
 
+  // ── Success screen ───────────────────────────────────────────────────────
+
   if (registered) {
     return (
-      <div className="text-center space-y-5">
-        <div className="w-14 h-14 rounded-2xl bg-indigo-500/10 flex items-center justify-center mx-auto">
-          <span className="text-2xl">✉️</span>
+      <div className="space-y-5">
+        <div className="w-10 h-10 border border-zinc-200 dark:border-zinc-700 flex items-center justify-center">
+          <span className="text-lg">✉️</span>
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-            {t("auth.signup.checkInboxTitle")}
-          </h1>
-          <p
-            className="text-sm text-zinc-500 dark:text-zinc-400 mt-2 leading-relaxed"
-            dangerouslySetInnerHTML={{
-              __html: t("auth.signup.checkInboxBody", { email: form.email }),
-            }}
-          />
+          <h1 className="text-xl font-bold">{t("auth.signup.checkInboxTitle")}</h1>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-2 leading-relaxed"
+            dangerouslySetInnerHTML={{ __html: t("auth.signup.checkInboxBody", { email: form.email }) }} />
         </div>
-        <Link
-          to="/login"
-          className="inline-block text-sm text-indigo-500 hover:text-indigo-600 font-medium transition-colors"
-        >
+        <Link to="/login" className="inline-block text-sm text-indigo-500 hover:text-indigo-600 font-medium transition-colors">
           {t("auth.signup.backToSignIn")}
         </Link>
       </div>
     );
   }
 
+  // ── Form ─────────────────────────────────────────────────────────────────
+
   return (
-    <div className="space-y-6">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{t("auth.signup.title")}</h1>
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{t("auth.signup.title")}</h1>
         <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">{t("auth.signup.subtitle")}</p>
       </div>
-      <form onSubmit={handleSubmit} className="space-y-4">
+
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+
+        {/* Name */}
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
-            {t("auth.signup.name")}
+          <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+            Full name
           </label>
           <input
             type="text"
-            required
+            autoComplete="name"
             value={form.name}
+            placeholder="Your full name"
             onChange={(e) => setForm({ ...form, name: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            onBlur={() => blur("name")}
+            className={`field-input ${show("name") ? "border-red-400 dark:border-red-500 focus:border-red-400" : ""}`}
           />
+          <FieldError msg={show("name") ? errors.name : ""} />
         </div>
+
+        {/* Email */}
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
-            {t("auth.signup.email")}
+          <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+            Email address
           </label>
-          <input
-            type="email"
-            required
-            value={form.email}
-            onChange={(e) => setForm({ ...form, email: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+          <div className="relative">
+            <input
+              type="email"
+              autoComplete="email"
+              value={form.email}
+              placeholder="you@example.com"
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+              onBlur={() => blur("email")}
+              className={`field-input pr-8 ${show("email") ? "border-red-400 dark:border-red-500 focus:border-red-400" : touched.email && !errors.email ? "border-emerald-400 dark:border-emerald-500" : ""}`}
+            />
+            {touched.email && !errors.email && (
+              <Check className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-emerald-500 pointer-events-none" />
+            )}
+          </div>
+          <FieldError msg={show("email") ? errors.email : ""} />
         </div>
+
+        {/* Password */}
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
-            {t("auth.signup.password")}
+          <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+            Password
           </label>
-          <input
-            type="password"
-            required
-            value={form.password}
-            onChange={(e) => setForm({ ...form, password: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
-          <PasswordStrength password={form.password} />
+          <div className="relative">
+            <input
+              type={showPassword ? "text" : "password"}
+              autoComplete="new-password"
+              value={form.password}
+              onChange={(e) => setForm({ ...form, password: e.target.value })}
+              onBlur={() => blur("password")}
+              className={`field-input pr-9 ${show("password") && errors.password ? "border-red-400 dark:border-red-500" : ""}`}
+            />
+            <button type="button" onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors">
+              {showPassword ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+          {/* Always show strength meter when typing */}
+          <PasswordStrengthMeter password={form.password} />
+          <FieldError msg={show("password") && errors.password ? errors.password : ""} />
         </div>
+
+        {/* Confirm password */}
         <div>
-          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1.5">
-            {t("auth.signup.confirmPassword")}
+          <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+            Confirm password
           </label>
-          <input
-            type="password"
-            required
-            value={form.confirm}
-            onChange={(e) => setForm({ ...form, confirm: e.target.value })}
-            className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+          <div className="relative">
+            <input
+              type={showConfirm ? "text" : "password"}
+              autoComplete="new-password"
+              value={form.confirm}
+              onChange={(e) => setForm({ ...form, confirm: e.target.value })}
+              onBlur={() => blur("confirm")}
+              className={`field-input pr-9 ${show("confirm") && errors.confirm ? "border-red-400 dark:border-red-500" : form.confirm && !errors.confirm ? "border-emerald-400 dark:border-emerald-500" : ""}`}
+            />
+            <button type="button" onClick={() => setShowConfirm((v) => !v)}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors">
+              {showConfirm ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+          <FieldError msg={show("confirm") ? errors.confirm : ""} />
         </div>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2.5 text-sm font-medium rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white transition-colors disabled:opacity-60"
-        >
+
+        {/* Terms note */}
+        <p className="text-[11px] text-zinc-400 dark:text-zinc-600 leading-relaxed">
+          By creating an account you agree to our{" "}
+          <span className="text-zinc-500 dark:text-zinc-400">Terms of Service</span> and{" "}
+          <span className="text-zinc-500 dark:text-zinc-400">Privacy Policy</span>.
+        </p>
+
+        <button type="submit" disabled={loading} className="btn-primary w-full py-2.5 justify-center">
           {loading ? t("auth.signup.submitting") : t("auth.signup.submit")}
         </button>
       </form>
-      <div className="relative flex items-center gap-3">
-        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-700" />
+
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
         <span className="text-xs text-zinc-400">{t("auth.signup.orSignUpWith")}</span>
-        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-700" />
+        <div className="flex-1 h-px bg-zinc-200 dark:bg-zinc-800" />
       </div>
+
       <div className="flex justify-center">
         <GoogleLogin onSuccess={handleGoogle} onError={() => toast.error("Google sign-up failed.")} />
       </div>
+
       <p className="text-center text-sm text-zinc-500 dark:text-zinc-400">
         {t("auth.signup.hasAccount")}{" "}
         <Link to="/login" className="text-indigo-500 hover:text-indigo-600 font-medium transition-colors">

--- a/frontend/src/pages/VerifyEmail.jsx
+++ b/frontend/src/pages/VerifyEmail.jsx
@@ -1,10 +1,10 @@
-// src/pages/VerifyEmail.jsx
 import React, { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { authApi } from "../features/auth/authservice";
 
 function VerifyEmail() {
-  const [message, setMessage] = useState("Verifying...");
+  const [status, setStatus] = useState("pending"); // pending | success | error
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -12,29 +12,59 @@ function VerifyEmail() {
     const params = new URLSearchParams(location.search);
     const token = params.get("token");
     if (!token) {
-      setMessage("Invalid verification link.");
+      setStatus("error");
       return;
     }
-
     const verify = async () => {
       try {
         await authApi.get(`/verify-email?token=${token}`);
-        setMessage("✅ Email verified! Redirecting...");
-        setTimeout(() => navigate("/"), 2500);
-      } catch (err) {
-        setMessage("❌ Verification failed. Link may be expired.");
+        setStatus("success");
+        setTimeout(() => navigate("/login"), 2500);
+      } catch {
+        setStatus("error");
       }
     };
-
     verify();
   }, [location.search, navigate]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-secondary">
-      <div className="card text-center space-y-4">
-        <h2 className="heading">Email Verification</h2>
-        <p className="text-muted">{message}</p>
-      </div>
+    <div className="text-center space-y-5">
+      {status === "pending" && (
+        <>
+          <Loader2 className="w-10 h-10 text-accent animate-spin mx-auto" />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Verifying your email</h1>
+            <p className="text-sm text-muted-foreground mt-1">Please wait a moment…</p>
+          </div>
+        </>
+      )}
+      {status === "success" && (
+        <>
+          <div className="w-12 h-12 bg-success-subtle flex items-center justify-center mx-auto" style={{ borderRadius: 2 }}>
+            <CheckCircle className="w-6 h-6 text-success" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Email verified</h1>
+            <p className="text-sm text-muted-foreground mt-1">Redirecting you to sign in…</p>
+          </div>
+        </>
+      )}
+      {status === "error" && (
+        <>
+          <div className="w-12 h-12 bg-error-subtle flex items-center justify-center mx-auto" style={{ borderRadius: 2 }}>
+            <XCircle className="w-6 h-6 text-error" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Verification failed</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              The link may be invalid or expired.
+            </p>
+          </div>
+          <Link to="/login" className="inline-block text-sm font-medium text-accent hover:text-accent-hover transition-colors">
+            Back to sign in
+          </Link>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -2,72 +2,191 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================================
+   DESIGN TOKEN SYSTEM
+   CSS custom properties → Tailwind semantic color names.
+   All tokens are defined here in one place.
+   Light values live in :root, dark values in .dark.
+   Components use semantic names (bg-surface, text-foreground…)
+   so they automatically adapt — no dark: variants needed.
+   ============================================================ */
+
 @layer base {
+
+  :root {
+    /* ── Surfaces ─────────────────────────────────────────── */
+    --background:      0 0% 100%;          /* page bg        */
+    --foreground:      240 10% 3.9%;       /* primary text   */
+
+    --surface:         0 0% 100%;          /* card / panel   */
+    --surface-raised:  0 0% 100%;          /* dropdown, popover */
+
+    --inset:           240 4.8% 95.9%;     /* table header, code block */
+    --muted:           240 4.8% 95.9%;     /* hover, tag bg  */
+    --muted-foreground: 240 3.7% 44.1%;   /* secondary text */
+    --subtle:          240 5% 64.9%;       /* placeholder, timestamps */
+
+    /* ── Borders ──────────────────────────────────────────── */
+    --border:          240 5.9% 90%;       /* default border */
+    --border-strong:   240 4.9% 83.9%;     /* emphasis border */
+
+    /* ── Accent (indigo-500 primary action) ───────────────── */
+    --accent:          239 84.2% 67.1%;
+    --accent-foreground: 0 0% 100%;
+    --accent-subtle:   239 68% 95%;        /* hover / selected tint */
+    --accent-hover:    243 75% 58.8%;      /* indigo-600 */
+
+    /* ── Status ───────────────────────────────────────────── */
+    --success:         142 71% 45.1%;
+    --success-subtle:  141 84% 93%;
+
+    --warning:         38 92% 50%;
+    --warning-subtle:  48 96% 89%;
+
+    --error:           0 84.2% 60.2%;
+    --error-subtle:    0 86% 93%;
+  }
+
+  .dark {
+    /* ── Surfaces ─────────────────────────────────────────── */
+    --background:      240 10% 3.9%;       /* zinc-950 */
+    --foreground:      0 0% 98%;           /* zinc-50  */
+
+    --surface:         240 5.9% 10%;       /* zinc-900 */
+    --surface-raised:  240 3.7% 15.9%;     /* zinc-800 */
+
+    --inset:           240 10% 3.9%;       /* slightly darker than surface */
+    --muted:           240 3.7% 15.9%;     /* zinc-800 */
+    --muted-foreground: 240 5% 64.9%;      /* zinc-400 */
+    --subtle:          240 3.7% 44.1%;     /* zinc-500 */
+
+    /* ── Borders ──────────────────────────────────────────── */
+    --border:          240 3.7% 15.9%;     /* zinc-800 */
+    --border-strong:   240 5.3% 26.1%;     /* zinc-700 */
+
+    /* ── Accent ───────────────────────────────────────────── */
+    --accent:          239 84.2% 67.1%;    /* indigo-500 — same */
+    --accent-foreground: 0 0% 100%;
+    --accent-subtle:   244 62% 17%;        /* very dark indigo tint */
+    --accent-hover:    234 89% 73.9%;      /* indigo-400 (lighter in dark) */
+
+    /* ── Status ───────────────────────────────────────────── */
+    --success:         160 84% 39.4%;
+    --success-subtle:  162 94% 7%;
+
+    --warning:         38 92% 50%;
+    --warning-subtle:  33 91% 9%;
+
+    --error:           0 84.2% 60.2%;
+    --error-subtle:    0 63% 8%;
+  }
+
+  /* Base text & background from tokens */
   html {
     @apply font-sans;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 
   body {
     @apply font-sans;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }
 
+/* ============================================================
+   COMPONENT CLASSES
+   Use semantic tokens so dark mode is automatic.
+   ============================================================ */
+
 @layer components {
-  .glass {
-    background-color: rgba(255, 255, 255, 0.8);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
+
+  /* ── Cards ────────────────────────────────────────────────── */
+  .studio-card {
+    @apply bg-surface border border-border;
+    border-radius: 2px;
   }
 
-  .dark .glass {
-    background-color: rgba(9, 9, 11, 0.8);
+  .studio-card-accent {
+    @apply studio-card border-t-2 border-t-accent;
   }
 
-  .glass-card {
-    @apply border border-zinc-200/80 bg-white;
+  /* ── Section rule heading ──────────────────────────────────── */
+  .section-label {
+    @apply text-[10px] font-semibold tracking-[0.18em] uppercase text-muted-foreground;
   }
 
-  .dark .glass-card {
-    @apply border-zinc-800 bg-zinc-900;
+  /* ── Table row ─────────────────────────────────────────────── */
+  .table-row-item {
+    @apply flex items-center gap-3 px-4 py-3 border-b border-border
+           hover:bg-muted transition-colors last:border-0;
+  }
+
+  /* ── Status pills ──────────────────────────────────────────── */
+  .status-done       { @apply text-[10px] font-semibold tracking-wide uppercase text-success; }
+  .status-processing { @apply text-[10px] font-semibold tracking-wide uppercase text-accent; }
+  .status-pending    { @apply text-[10px] font-semibold tracking-wide uppercase text-muted-foreground; }
+  .status-failed     { @apply text-[10px] font-semibold tracking-wide uppercase text-error; }
+
+  /* ── Input ─────────────────────────────────────────────────── */
+  .field-input {
+    @apply w-full px-3 py-2 text-sm
+           bg-surface text-foreground
+           border border-border
+           focus:outline-none focus:border-accent
+           focus:ring-0
+           placeholder:text-subtle;
+    border-radius: 2px;
+  }
+
+  /* ── Buttons ───────────────────────────────────────────────── */
+  .btn-primary {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2
+           text-sm font-medium text-accent-foreground bg-accent
+           hover:bg-accent-hover
+           transition-colors disabled:opacity-50;
+    border-radius: 2px;
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2
+           text-sm font-medium
+           text-foreground
+           bg-transparent border border-border
+           hover:border-border-strong
+           hover:bg-muted
+           transition-colors disabled:opacity-50;
+    border-radius: 2px;
+  }
+
+  .btn-danger {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2
+           text-sm font-medium text-error
+           border border-error/30
+           hover:bg-error-subtle
+           transition-colors disabled:opacity-50;
+    border-radius: 2px;
+  }
+
+  /* ── Skeleton ──────────────────────────────────────────────── */
+  .skel {
+    @apply bg-muted animate-pulse;
+    border-radius: 2px;
   }
 }
 
 @layer utilities {
-  .animate-fade-in {
-    animation: fadeIn 0.15s ease-out;
-  }
-
-  .animate-scale-in {
-    animation: scaleIn 0.15s ease-out;
-  }
-
-  .animate-slide-up {
-    animation: slideUp 0.2s ease-out;
-  }
+  .animate-fade-in  { animation: fadeIn  0.2s ease-out; }
+  .animate-slide-up { animation: slideUp 0.25s ease-out; }
 }
 
 @keyframes fadeIn {
   from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.97); }
-  to { opacity: 1; transform: scale(1); }
+  to   { opacity: 1; }
 }
 
 @keyframes slideUp {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.text-gradient {
-  background-image: linear-gradient(to right, #6366f1, #8b5cf6, #a855f7);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.hero-glow {
-  background: radial-gradient(ellipse 80% 50% at 50% -5%, rgba(99, 102, 241, 0.13), transparent 70%);
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,35 @@
 import forms from '@tailwindcss/forms'
 import typography from '@tailwindcss/typography'
 
+/**
+ * Design Token System
+ * -------------------
+ * Semantic color names reference CSS custom properties defined in index.css.
+ * This means every token automatically adapts to dark mode — no `dark:` variant needed.
+ *
+ * Usage:
+ *   bg-background    → page background
+ *   bg-surface       → card / panel background
+ *   bg-surface-raised→ elevated surface (dropdowns, popovers)
+ *   bg-inset         → subtle indented areas (table headers, code blocks)
+ *   bg-muted         → hover states, tags
+ *
+ *   text-foreground  → primary body text
+ *   text-muted       → secondary / supporting text
+ *   text-subtle      → placeholder, timestamps, tertiary
+ *
+ *   border-border    → default border
+ *   border-strong    → stronger border for emphasis
+ *
+ *   bg-accent        → indigo-500 primary action
+ *   text-accent      → indigo-500 text links
+ *   bg-accent-subtle → light indigo tint for hover/selected states
+ *
+ *   bg-success-subtle / text-success
+ *   bg-warning-subtle / text-warning
+ *   bg-error-subtle  / text-error
+ */
+
 export default {
   darkMode: 'class',
   content: [
@@ -8,40 +37,76 @@ export default {
     './src/**/*.{js,jsx,ts,tsx}',
   ],
   theme: {
-    container: {
-      center: true,
-      padding: '1rem',
-    },
+    container: { center: true, padding: '1rem' },
     extend: {
       colors: {
+        // ── Semantic surface tokens ───────────────────────────────────────
+        background:      'hsl(var(--background))',
+        foreground:      'hsl(var(--foreground))',
+
+        surface: {
+          DEFAULT:  'hsl(var(--surface))',
+          raised:   'hsl(var(--surface-raised))',
+        },
+        inset:           'hsl(var(--inset))',
+        muted: {
+          DEFAULT:  'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        subtle:          'hsl(var(--subtle))',
+
+        // ── Border tokens ─────────────────────────────────────────────────
+        border: {
+          DEFAULT: 'hsl(var(--border))',
+          strong:  'hsl(var(--border-strong))',
+        },
+
+        // ── Accent (primary action) ───────────────────────────────────────
+        accent: {
+          DEFAULT:  'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+          subtle:   'hsl(var(--accent-subtle))',
+          hover:    'hsl(var(--accent-hover))',
+        },
+
+        // ── Status tokens ─────────────────────────────────────────────────
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          subtle:  'hsl(var(--success-subtle))',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          subtle:  'hsl(var(--warning-subtle))',
+        },
+        error: {
+          DEFAULT: 'hsl(var(--error))',
+          subtle:  'hsl(var(--error-subtle))',
+        },
+
+        // ── Keep legacy zinc/indigo for existing components ───────────────
         primary: {
           DEFAULT: '#0f172a',
-          light: '#1e293b',
-          dark: '#020617',
-        },
-        secondary: {
-          DEFAULT: '#0ea5e9',
-          light: '#38bdf8',
-          dark: '#0284c7',
-        },
-        background: {
-          DEFAULT: '#ffffff',
-          dark: '#0f172a',
-          subtle: '#f1f5f9',
-        },
-        content: { // ✅ renamed from `text`
-          DEFAULT: '#0f172a',
-          light: '#e2e8f0',
-          muted: '#64748b',
-          dark: '#94a3b8',
+          light:   '#1e293b',
+          dark:    '#020617',
         },
       },
+
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui'],
       },
+
       borderRadius: {
-        xl: '1rem',
-        '2xl': '1.5rem',
+        DEFAULT: '2px',
+        sm:      '2px',
+        md:      '4px',
+        lg:      '6px',
+        xl:      '8px',
+        '2xl':   '12px',
+        full:    '9999px',
+      },
+
+      fontSize: {
+        '2xs': ['0.65rem', { lineHeight: '1rem' }],
       },
     },
   },


### PR DESCRIPTION
## Summary
- **Design token system** — CSS custom properties in `:root`/`.dark` registered as semantic Tailwind names (`bg-surface`, `text-foreground`, `border-border`, `bg-accent`, status tokens). Dark mode is now automatic — no `dark:` variants needed in new code.
- **New design language** — sharp 2px corners throughout, editorial layout on LandingPage (asymmetric hero, numbered feature rows), table-style document lists on Dashboard and ConvertPage, left-border active indicator on Sidebar nav
- **ConvertPage enhancements** — client-side search, bulk select with action bar, live elapsed timer for in-progress OCR, sortable columns, `U` keyboard shortcut to open file picker
- **Auth flow** — industry-standard signup validation: `EMAIL_RE`, 4-rule `PASSWORD_RULES`, `PasswordStrengthMeter` (4-bar + checklist), blur-triggered errors, show/hide password toggle; same strength UI on ResetPasswordPage

## Fixes
- Modal transparency — was using a removed CSS class; replaced with `bg-surface` + indigo top border + close button
- PricingPage dark mode — plan cards had no background in dark mode (dark text on dark bg); now use `bg-surface`/`text-foreground`
- VerifyEmail — was using dead class names (`card`, `heading`, `bg-secondary`); replaced with proper spinner/success/error states using design tokens
- ForgotPasswordPage and ResetPasswordPage — updated inputs/buttons to `field-input`/`btn-primary`, matching the rest of the auth flow

## Test plan
- [ ] Light and dark mode on all pages — check no white-on-white or black-on-black text
- [ ] Sign up with invalid email / weak password — errors should appear on blur
- [ ] Password reset flow end-to-end — strength meter visible on ResetPasswordPage
- [ ] ConvertPage: upload files, search, bulk select, sort columns
- [ ] VerifyEmail with valid/invalid/missing token

🤖 Generated with [Claude Code](https://claude.com/claude-code)