### PR TITLE
chore: unify OCR pipeline into shared pipeline.py

### DIFF
--- a/ocr-worker/local_app.py
+++ b/ocr-worker/local_app.py
@@ -1,0 +1,248 @@
+"""
+Textara OCR — local dev HTTP server
+====================================
+Wraps pipeline.py. Loads the Qari model eagerly at startup.
+
+Endpoints:
+  POST /process   — upload PDF, receive DOCX bytes
+  GET  /metrics   — Prometheus metrics
+  GET  /stats     — JSON stats summary
+  GET  /health    — liveness check
+
+Usage:
+    cd ocr-worker
+    uvicorn local_app:app --host 0.0.0.0 --port 8002
+"""
+
+import io
+import time
+import logging
+import tempfile
+import pathlib
+from contextlib import asynccontextmanager
+
+import torch
+from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi.responses import Response, JSONResponse
+from prometheus_client import (
+    Counter, Histogram, Gauge,
+    generate_latest, CONTENT_TYPE_LATEST,
+)
+
+import pipeline as ocr
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("textara-ocr")
+
+# ── Prometheus metrics ────────────────────────────────────────────────────────
+
+REQUEST_TOTAL = Counter(
+    "ocr_requests_total",
+    "Total OCR requests by outcome",
+    ["status"],          # "success" | "error"
+)
+PAGE_TOTAL = Counter(
+    "ocr_pages_total",
+    "Total pages processed",
+)
+REQUEST_DURATION = Histogram(
+    "ocr_request_duration_seconds",
+    "End-to-end request processing time (seconds)",
+    buckets=[2, 5, 10, 30, 60, 120, 300, 600],
+)
+PAGE_DURATION = Histogram(
+    "ocr_page_duration_seconds",
+    "Per-page Qari OCR time (seconds)",
+    buckets=[0.5, 1, 2, 3, 5, 10, 20, 40],
+)
+VRAM_USED = Gauge(
+    "ocr_vram_used_bytes",
+    "Current GPU VRAM allocated (bytes)",
+)
+VRAM_TOTAL = Gauge(
+    "ocr_vram_total_bytes",
+    "Total GPU VRAM available (bytes)",
+)
+MODEL_LOAD_TIME = Gauge(
+    "ocr_model_load_seconds",
+    "Seconds taken to load the Qari model",
+)
+MODEL_READY = Gauge(
+    "ocr_model_ready",
+    "1 if the Qari model is loaded and ready, 0 otherwise",
+)
+
+# ── Runtime state ─────────────────────────────────────────────────────────────
+
+_model     = None
+_processor = None
+
+_stats = {
+    "requests": {"total": 0, "success": 0, "error": 0},
+    "pages":    {"total": 0},
+    "timing":   {"total_page_seconds": 0.0, "total_request_seconds": 0.0},
+    "model":    {"loaded": False, "load_time_seconds": None},
+}
+
+# ── Startup / shutdown ────────────────────────────────────────────────────────
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _model, _processor
+
+    MODEL_READY.set(0)
+    log.info("Loading Qari model at startup...")
+
+    _model, _processor, load_time = ocr.load_model()
+
+    _stats["model"]["loaded"]            = True
+    _stats["model"]["load_time_seconds"] = round(load_time, 2)
+    MODEL_LOAD_TIME.set(load_time)
+    MODEL_READY.set(1)
+    _update_vram_gauges()
+
+    log.info(f"Qari model ready — load time {load_time:.1f}s")
+    yield
+    log.info("Server shutting down")
+
+
+app = FastAPI(title="Textara OCR Dev Server", lifespan=lifespan)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _update_vram_gauges():
+    if torch.cuda.is_available():
+        VRAM_USED.set(torch.cuda.memory_allocated())
+        VRAM_TOTAL.set(torch.cuda.get_device_properties(0).total_memory)
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@app.post("/process")
+async def process_pdf(file: UploadFile = File(...)):
+    """Accept a PDF upload, return DOCX bytes."""
+    if file.content_type not in ("application/pdf", "application/octet-stream"):
+        raise HTTPException(status_code=400, detail="PDF required")
+
+    req_start = time.time()
+    _stats["requests"]["total"] += 1
+    log.info(f"Request — file={file.filename!r}")
+
+    tmp_path = None
+    try:
+        pdf_bytes = await file.read()
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(pdf_bytes)
+            tmp_path = pathlib.Path(tmp.name)
+
+        pdf_doc = ocr.open_pdf(tmp_path)
+        n_pages = len(pdf_doc)
+        log.info(f"  {n_pages} page(s) to process")
+
+        pages_text = []
+        for i, page in enumerate(pdf_doc, 1):
+            log.info(f"  Page {i}/{n_pages} — rendering")
+            img = ocr.render_page(page)
+            text, page_elapsed, vram_delta = ocr.ocr_page(img, _model, _processor)
+            pages_text.append(text)
+
+            PAGE_DURATION.observe(page_elapsed)
+            PAGE_TOTAL.inc()
+            _stats["pages"]["total"] += 1
+            _stats["timing"]["total_page_seconds"] += page_elapsed
+
+            log.info(
+                f"  Page {i}/{n_pages} done — "
+                f"{page_elapsed:.2f}s | {len(text)} chars | "
+                f"vram_delta={vram_delta/1e6:+.1f} MB"
+            )
+
+        pdf_doc.close()
+        _update_vram_gauges()
+
+        buf = io.BytesIO()
+        ocr.build_docx(pages_text, buf)
+        buf.seek(0)
+
+        req_elapsed = time.time() - req_start
+        REQUEST_DURATION.observe(req_elapsed)
+        REQUEST_TOTAL.labels(status="success").inc()
+        _stats["requests"]["success"] += 1
+        _stats["timing"]["total_request_seconds"] += req_elapsed
+
+        log.info(f"Request complete — {req_elapsed:.2f}s total ({n_pages} pages)")
+
+        return Response(
+            content=buf.read(),
+            media_type=(
+                "application/vnd.openxmlformats-officedocument"
+                ".wordprocessingml.document"
+            ),
+        )
+
+    except Exception as e:
+        req_elapsed = time.time() - req_start
+        REQUEST_TOTAL.labels(status="error").inc()
+        _stats["requests"]["error"] += 1
+        log.error(f"Request failed after {req_elapsed:.2f}s — {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+    finally:
+        if tmp_path:
+            tmp_path.unlink(missing_ok=True)
+
+
+@app.get("/metrics")
+def metrics():
+    """Prometheus metrics — scrape this from Grafana/Prometheus."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/stats")
+def stats():
+    """JSON stats summary — quick human-readable overview."""
+    total_pages = _stats["pages"]["total"]
+    total_ok    = _stats["requests"]["success"]
+
+    avg_page = (
+        _stats["timing"]["total_page_seconds"] / total_pages
+        if total_pages else None
+    )
+    avg_req = (
+        _stats["timing"]["total_request_seconds"] / total_ok
+        if total_ok else None
+    )
+
+    vram = {}
+    if torch.cuda.is_available():
+        props = torch.cuda.get_device_properties(0)
+        vram = {
+            "device":   props.name,
+            "used_gb":  round(torch.cuda.memory_allocated() / 1e9, 2),
+            "total_gb": round(props.total_memory / 1e9, 2),
+        }
+
+    return JSONResponse({
+        "requests": _stats["requests"],
+        "pages":    {"total": total_pages},
+        "timing": {
+            "avg_page_seconds":    round(avg_page, 2) if avg_page is not None else None,
+            "avg_request_seconds": round(avg_req,  2) if avg_req  is not None else None,
+        },
+        "vram":  vram,
+        "model": _stats["model"],
+    })
+
+
+@app.get("/health")
+def health():
+    return {
+        "status":       "ok",
+        "model_loaded": _stats["model"]["loaded"],
+    }

--- a/ocr-worker/modal_app.py
+++ b/ocr-worker/modal_app.py
@@ -1,17 +1,10 @@
 """
 Textara OCR Pipeline — Modal GPU endpoint
 ==========================================
+Production wrapper around pipeline.py for Modal.com.
+
 Receives a PDF as raw bytes, returns a DOCX as raw bytes.
-
-Pipeline per page:
-  1. PyMuPDF renders each page as a PIL image at 150 DPI
-  2. Full-page image sent to Qari OCR (Qwen2-VL 2B) in one shot
-  3. Assemble python-docx with RTL styles
-
-Model loading:
-  - bf16 Qwen2-VL-2B-Instruct base (SDPA attention)
-  - Qari LoRA applied then merged (removes adapter overhead)
-  - torch.compile(reduce-overhead) for faster repeated inference
+All OCR logic lives in pipeline.py — edit that file, not this one.
 
 Deploy:  modal deploy ocr-worker/modal_app.py
 Call:    OCRPipeline = modal.Cls.from_name("textara-ocr", "OCRPipeline")
@@ -44,18 +37,6 @@ image = (
 
 app = modal.App("textara-ocr", image=image)
 
-BASE_MODEL_ID = "Qwen/Qwen2-VL-2B-Instruct"
-LORA_MODEL_ID = "NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct"
-
-DPI        = 150
-MAX_PIXELS = 1280 * 28 * 28 * 4   # ~4 M pixels — full A4 page at 150 DPI fits without downscaling
-
-OCR_PROMPT = (
-    "Below is the image of one page of a document, as well as some raw textual content "
-    "that was previously extracted for it. Just return the plain text representation of "
-    "this document as if you were reading it naturally. Do not hallucinate."
-)
-
 
 @app.cls(
     gpu="A10G",
@@ -65,50 +46,14 @@ OCR_PROMPT = (
 class OCRPipeline:
     @modal.enter()
     def load_models(self):
-        import time
-        import torch
-        from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
-        from peft import PeftModel
-
-        t0 = time.time()
-
-        print(f"Loading {BASE_MODEL_ID} (bf16 base, SDPA)...")
-        base = Qwen2VLForConditionalGeneration.from_pretrained(
-            BASE_MODEL_ID,
-            torch_dtype=torch.bfloat16,
-            device_map="auto",
-            attn_implementation="sdpa",
-        ).eval()
-
-        print(f"Applying Qari LoRA ({LORA_MODEL_ID}) + merging weights...")
-        model = PeftModel.from_pretrained(base, LORA_MODEL_ID)
-        model = model.merge_and_unload()
-        model.generation_config.temperature = None
-        model.generation_config.top_p = None
-        model.generation_config.top_k = None
-        model.eval()
-
-        self.processor = AutoProcessor.from_pretrained(BASE_MODEL_ID, use_fast=True)
-
-        print("Compiling model (reduce-overhead)...")
-        self.model = torch.compile(model, mode="reduce-overhead", fullgraph=False)
-
-        elapsed = time.time() - t0
-        vram_gb = torch.cuda.memory_allocated() / 1e9
-        print(f"Model ready in {elapsed:.1f}s | VRAM: {vram_gb:.2f} GB")
+        from pipeline import load_model
+        self.model, self.processor, _ = load_model()
 
     @modal.method()
     def process_pdf(self, pdf_bytes: bytes) -> bytes:
         """Takes raw PDF bytes, returns raw DOCX bytes."""
         import fitz
-        import torch
-        from docx import Document
-        from docx.shared import Pt, RGBColor
-        from docx.enum.text import WD_ALIGN_PARAGRAPH
-        from docx.oxml.ns import qn
-        from docx.oxml import OxmlElement
-        from PIL import Image
-        from qwen_vl_utils import process_vision_info
+        from pipeline import render_page, ocr_page, build_docx
 
         pdf_doc = fitz.open(stream=pdf_bytes, filetype="pdf")
         n_pages = len(pdf_doc)
@@ -117,84 +62,15 @@ class OCRPipeline:
         pages_text = []
         for i, page in enumerate(pdf_doc, 1):
             print(f"  Page {i}/{n_pages} — rendering...")
-            mat = fitz.Matrix(DPI / 72, DPI / 72)
-            pix = page.get_pixmap(matrix=mat, colorspace=fitz.csRGB)
-            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
-
+            img = render_page(page)
             print(f"  Page {i}/{n_pages} — OCR ({img.width}x{img.height}px)...")
-            messages = [{
-                "role": "user",
-                "content": [
-                    {"type": "image", "image": img, "max_pixels": MAX_PIXELS},
-                    {"type": "text", "text": OCR_PROMPT},
-                ],
-            }]
-
-            text_input = self.processor.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
-            image_inputs, video_inputs = process_vision_info(messages)
-            inputs = self.processor(
-                text=[text_input],
-                images=image_inputs,
-                videos=video_inputs,
-                padding=True,
-                return_tensors="pt",
-            ).to(self.model.device)
-
-            with torch.inference_mode():
-                ids = self.model.generate(
-                    **inputs,
-                    max_new_tokens=2048,
-                    do_sample=False,
-                    num_beams=1,
-                )
-
-            trimmed = ids[:, inputs["input_ids"].shape[1]:]
-            text = self.processor.batch_decode(
-                trimmed,
-                skip_special_tokens=True,
-                clean_up_tokenization_spaces=True,
-            )[0].strip()
-
-            print(f"  Page {i}/{n_pages} — {len(text)} chars extracted")
+            text, elapsed, _ = ocr_page(img, self.model, self.processor)
+            print(f"  Page {i}/{n_pages} — {len(text)} chars in {elapsed:.1f}s")
             pages_text.append(text)
 
         pdf_doc.close()
 
-        # Build DOCX
-        doc = Document()
-
-        sectPr = doc.sections[0]._sectPr
-        bidi_el = OxmlElement("w:bidi")
-        sectPr.append(bidi_el)
-
-        for page_num, text in enumerate(pages_text, 1):
-            if page_num > 1:
-                sep = doc.add_paragraph(f"-- Page {page_num} --")
-                sep.alignment = WD_ALIGN_PARAGRAPH.CENTER
-                for run in sep.runs:
-                    run.font.color.rgb = RGBColor(0x99, 0x99, 0x99)
-                    run.font.size = Pt(9)
-
-            for line in text.split("\n"):
-                line = line.strip()
-                if not line:
-                    doc.add_paragraph("")
-                    continue
-                para = doc.add_paragraph(line)
-                para.alignment = WD_ALIGN_PARAGRAPH.RIGHT
-
-                pPr = para._p.get_or_add_pPr()
-                bidi = OxmlElement("w:bidi")
-                bidi.set(qn("w:val"), "1")
-                pPr.append(bidi)
-
-                for run in para.runs:
-                    run.font.name = "Arial"
-                    run.font.size = Pt(12)
-
         buf = io.BytesIO()
-        doc.save(buf)
+        build_docx(pages_text, buf)
         print("Done.")
         return buf.getvalue()

--- a/ocr-worker/pipeline.py
+++ b/ocr-worker/pipeline.py
@@ -1,0 +1,234 @@
+"""
+Textara OCR Pipeline — Qari (Qwen2-VL 2B)
+==========================================
+Core OCR logic shared by local_app.py (local dev) and modal_app.py (prod).
+
+Each page is rendered as a full-page image and passed to Qari in one shot.
+150 DPI gives ~1241x1754px for A4 — enough detail for the model to read
+the full page without hitting EOS early.
+
+CLI usage:
+    python pipeline.py input.pdf -o output.docx
+"""
+
+import sys
+import time
+import argparse
+from pathlib import Path
+
+import fitz  # PyMuPDF
+import torch
+from PIL import Image
+from docx import Document
+from docx.shared import Pt, RGBColor
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+BASE_MODEL_ID = "Qwen/Qwen2-VL-2B-Instruct"
+LORA_MODEL_ID = "NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct"
+
+# 150 DPI -> A4 page ~= 1241x1754 px = ~2.2M pixels.
+# MAX_PIXELS=4M lets the full page through without downscaling.
+DPI        = 150
+MAX_PIXELS = 1280 * 28 * 28 * 4
+
+OCR_PROMPT = (
+    "Below is the image of one page of a document, as well as some raw textual content "
+    "that was previously extracted for it. Just return the plain text representation of "
+    "this document as if you were reading it naturally. Do not hallucinate."
+)
+
+# ── Model ─────────────────────────────────────────────────────────────────────
+
+def load_model():
+    """Load Qari LoRA merged onto bf16 Qwen2-VL-2B base.
+
+    Loads full-precision base, applies Qari LoRA, merges weights so inference
+    uses native bf16 matmuls (no bnb dequantize overhead).
+    SDPA in torch 2.4+ automatically uses Flash Attention 2 for bf16 on Ampere GPUs.
+    Returns (model, processor, load_time_seconds).
+    """
+    from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
+    from peft import PeftModel
+
+    t0 = time.time()
+
+    print(f"Loading {BASE_MODEL_ID} (bf16 base, SDPA)...")
+    base = Qwen2VLForConditionalGeneration.from_pretrained(
+        BASE_MODEL_ID,
+        torch_dtype=torch.bfloat16,
+        device_map="auto",
+        attn_implementation="sdpa",
+    ).eval()
+
+    print(f"Applying Qari LoRA ({LORA_MODEL_ID}) + merging weights...")
+    model = PeftModel.from_pretrained(base, LORA_MODEL_ID)
+    model = model.merge_and_unload()
+    model.generation_config.temperature = None
+    model.generation_config.top_p = None
+    model.generation_config.top_k = None
+    model.eval()
+
+    processor = AutoProcessor.from_pretrained(BASE_MODEL_ID, use_fast=True)
+
+    print("Compiling model (reduce-overhead)...")
+    model = torch.compile(model, mode="reduce-overhead", fullgraph=False)
+
+    elapsed = time.time() - t0
+    vram_gb = torch.cuda.memory_allocated() / 1e9 if torch.cuda.is_available() else 0
+    print(f"Model ready in {elapsed:.1f}s | VRAM: {vram_gb:.2f} GB")
+    return model, processor, elapsed
+
+# ── PDF ───────────────────────────────────────────────────────────────────────
+
+def open_pdf(pdf_path: Path):
+    """Open a PDF and return the fitz Document."""
+    doc = fitz.open(str(pdf_path))
+    print(f"PDF: {len(doc)} page(s)")
+    return doc
+
+# ── Page rendering ────────────────────────────────────────────────────────────
+
+def render_page(page) -> Image.Image:
+    """Render a PDF page to a PIL Image at DPI resolution."""
+    mat = fitz.Matrix(DPI / 72, DPI / 72)
+    pix = page.get_pixmap(matrix=mat, colorspace=fitz.csRGB)
+    return Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+
+# ── OCR ───────────────────────────────────────────────────────────────────────
+
+def ocr_page(image: Image.Image, model, processor) -> tuple:
+    """Run Qari OCR on a full-page PIL image.
+
+    Returns (text, elapsed_seconds, vram_delta_bytes).
+    """
+    from qwen_vl_utils import process_vision_info
+
+    vram_before = torch.cuda.memory_allocated() if torch.cuda.is_available() else 0
+    t0 = time.time()
+
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image", "image": image, "max_pixels": MAX_PIXELS},
+            {"type": "text",  "text": OCR_PROMPT},
+        ],
+    }]
+
+    text_input = processor.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    image_inputs, video_inputs = process_vision_info(messages)
+    inputs = processor(
+        text=[text_input],
+        images=image_inputs,
+        videos=video_inputs,
+        padding=True,
+        return_tensors="pt",
+    ).to(model.device)
+
+    with torch.inference_mode():
+        ids = model.generate(
+            **inputs,
+            max_new_tokens=2048,
+            do_sample=False,
+            num_beams=1,
+        )
+
+    trimmed = ids[:, inputs["input_ids"].shape[1]:]
+    text = processor.batch_decode(
+        trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=True
+    )[0].strip()
+
+    elapsed    = time.time() - t0
+    vram_delta = (torch.cuda.memory_allocated() if torch.cuda.is_available() else 0) - vram_before
+    return text, elapsed, vram_delta
+
+# ── DOCX builder ──────────────────────────────────────────────────────────────
+
+def _set_rtl_paragraph(para):
+    pPr = para._p.get_or_add_pPr()
+    bidi = OxmlElement("w:bidi")
+    bidi.set(qn("w:val"), "1")
+    pPr.append(bidi)
+    para.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+
+
+def build_docx(pages_text: list, out_path):
+    """Build an RTL DOCX from a list of per-page text strings."""
+    doc = Document()
+
+    sectPr = doc.sections[0]._sectPr
+    bidi_el = OxmlElement("w:bidi")
+    sectPr.append(bidi_el)
+
+    for page_num, text in enumerate(pages_text, 1):
+        if page_num > 1:
+            sep = doc.add_paragraph(f"-- Page {page_num} --")
+            sep.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            for run in sep.runs:
+                run.font.color.rgb = RGBColor(0x99, 0x99, 0x99)
+                run.font.size = Pt(9)
+
+        for line in text.split("\n"):
+            line = line.strip()
+            if not line:
+                doc.add_paragraph("")
+                continue
+            para = doc.add_paragraph(line)
+            _set_rtl_paragraph(para)
+            for run in para.runs:
+                run.font.name = "Arial"
+                run.font.size = Pt(12)
+
+    doc.save(out_path)
+    if hasattr(out_path, "name"):
+        print(f"Saved -> {out_path.name}")
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Textara OCR Pipeline (Qari)")
+    parser.add_argument("pdf",            help="Input PDF path")
+    parser.add_argument("-o", "--output", help="Output DOCX path")
+    args = parser.parse_args()
+
+    pdf_path = Path(args.pdf).expanduser().resolve()
+    if not pdf_path.exists():
+        print(f"Error: {pdf_path} not found")
+        sys.exit(1)
+    out_path = Path(args.output) if args.output else pdf_path.with_suffix(".docx")
+
+    print(f"\n{'='*60}")
+    print(f"  Textara OCR Pipeline (Qari, full-page one-shot)")
+    print(f"  Input : {pdf_path.name}")
+    print(f"  Output: {out_path.name}")
+    print(f"{'='*60}\n")
+
+    print("[1/3] Loading model...")
+    model, processor, load_time = load_model()
+
+    print(f"\n[2/3] Processing pages...")
+    pdf_doc = open_pdf(pdf_path)
+    n = len(pdf_doc)
+
+    pages_text = []
+    for i, page in enumerate(pdf_doc, 1):
+        print(f"  Page {i}/{n} — rendering...", end=" ", flush=True)
+        img = render_page(page)
+        print(f"({img.width}x{img.height}px) OCR...", end=" ", flush=True)
+        text, elapsed, _ = ocr_page(img, model, processor)
+        print(f"done ({elapsed:.1f}s, {len(text)} chars)")
+        pages_text.append(text)
+    pdf_doc.close()
+
+    print(f"\n[3/3] Building DOCX...")
+    build_docx(pages_text, out_path)
+    print(f"\nComplete — {n} page(s) | model load {load_time:.1f}s\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Splits `ocr-worker/` into three files with clear responsibilities:
  - `pipeline.py` — core OCR logic, single source of truth for both local dev and prod
  - `local_app.py` — local dev HTTP server (replaces the standalone `server.py` on desktop)
  - `modal_app.py` — thin Modal wrapper, now imports from `pipeline.py` instead of duplicating logic
- No logic changes — same model loading, DPI (150), MAX\_PIXELS (4M), prompt, and DOCX building as currently in prod

## Why
Previously the desktop `~/ocr-pipeline/` and `modal_app.py` were two separate copies of the same logic that drifted out of sync. Now `pipeline.py` is the single place to make OCR changes, and both environments use it.

## Desktop setup after merge
Clone/pull the repo on the desktop and run the server from `ocr-worker/`:
```bash
cd ~/arabic-ocr-web/ocr-worker
~/ocr-pipeline/venv/bin/uvicorn local_app:app --host 0.0.0.0 --port 8002
```

## Test plan
- [ ] CI build passes
- [ ] Review `pipeline.py` matches current working desktop logic
- [ ] Review `modal_app.py` is a clean thin wrapper
- [ ] After merge to `main`: verify Modal deploy succeeds and OCR still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)