### PR TITLE
fix: mount pipeline.py into Modal container

### DIFF
--- a/ocr-worker/modal_app.py
+++ b/ocr-worker/modal_app.py
@@ -37,11 +37,17 @@ image = (
 
 app = modal.App("textara-ocr", image=image)
 
+pipeline_mount = modal.Mount.from_local_file(
+    local_path="ocr-worker/pipeline.py",
+    remote_path="/root/pipeline.py",
+)
+
 
 @app.cls(
     gpu="A10G",
     timeout=600,
     min_containers=0,
+    mounts=[pipeline_mount],
 )
 class OCRPipeline:
     @modal.enter()


### PR DESCRIPTION
## Summary
- `ModuleNotFoundError: No module named 'pipeline'` crashing all OCR requests in prod
- `modal_app.py` imports from `pipeline.py` but Modal wasn't bundling it into the container
- Fix: add `modal.Mount.from_local_file` to explicitly copy `pipeline.py` into `/root/pipeline.py` at deploy time

## Test plan
- [ ] CI passes
- [ ] After merge, `modal app logs textara-ocr` shows model loading successfully
- [ ] Test a PDF conversion on textara.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)