### PR TITLE
fix: use image.add_local_file to bundle pipeline.py (modal.Mount removed in v1.x)

### DIFF
--- a/ocr-worker/modal_app.py
+++ b/ocr-worker/modal_app.py
@@ -33,21 +33,16 @@ image = (
         "Pillow",
         "python-docx",
     )
+    .add_local_file("ocr-worker/pipeline.py", "/root/pipeline.py")
 )
 
 app = modal.App("textara-ocr", image=image)
-
-pipeline_mount = modal.Mount.from_local_file(
-    local_path="ocr-worker/pipeline.py",
-    remote_path="/root/pipeline.py",
-)
 
 
 @app.cls(
     gpu="A10G",
     timeout=600,
     min_containers=0,
-    mounts=[pipeline_mount],
 )
 class OCRPipeline:
     @modal.enter()


### PR DESCRIPTION
## Summary
- Previous fix used `modal.Mount.from_local_file` which was removed in Modal v1.x, causing deploy to fail with `AttributeError: module 'modal' has no attribute 'Mount'`
- Fix: use `image.add_local_file("ocr-worker/pipeline.py", "/root/pipeline.py")` — the correct v1.x API to bundle local files into the container image

## Test plan
- [ ] CI passes
- [ ] After merge, Modal deploy succeeds and `pipeline.py` is importable in the container
- [ ] Test a PDF conversion on textara.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)