### PR TITLE
fix: sync hotfix - use image.add_local_file to bundle pipeline.py

### DIFF
--- a/ocr-worker/modal_app.py
+++ b/ocr-worker/modal_app.py
@@ -33,21 +33,16 @@ image = (
         "Pillow",
         "python-docx",
     )
+    .add_local_file("ocr-worker/pipeline.py", "/root/pipeline.py")
 )
 
 app = modal.App("textara-ocr", image=image)
-
-pipeline_mount = modal.Mount.from_local_file(
-    local_path="ocr-worker/pipeline.py",
-    remote_path="/root/pipeline.py",
-)
 
 
 @app.cls(
     gpu="A10G",
     timeout=600,
     min_containers=0,
-    mounts=[pipeline_mount],
 )
 class OCRPipeline:
     @modal.enter()

--- a/ocr-worker/modal_app.py
+++ b/ocr-worker/modal_app.py
@@ -37,11 +37,17 @@ image = (
 
 app = modal.App("textara-ocr", image=image)
 
+pipeline_mount = modal.Mount.from_local_file(
+    local_path="ocr-worker/pipeline.py",
+    remote_path="/root/pipeline.py",
+)
+
 
 @app.cls(
     gpu="A10G",
     timeout=600,
     min_containers=0,
+    mounts=[pipeline_mount],
 )
 class OCRPipeline:
     @modal.enter()


### PR DESCRIPTION
Syncing hotfix from `main` → `dev` to keep branches in sync.

Fixes `ModuleNotFoundError: No module named 'pipeline'` in Modal by using `image.add_local_file()` instead of the removed `modal.Mount` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)