### PR TITLE
fix: remove torch.compile — causes silent empty OCR output on Modal A10G

### DIFF
--- a/ocr-worker/pipeline.py
+++ b/ocr-worker/pipeline.py
@@ -74,9 +74,6 @@ def load_model():
 
     processor = AutoProcessor.from_pretrained(BASE_MODEL_ID, use_fast=True)
 
-    print("Compiling model (reduce-overhead)...")
-    model = torch.compile(model, mode="reduce-overhead", fullgraph=False)
-
     elapsed = time.time() - t0
     vram_gb = torch.cuda.memory_allocated() / 1e9 if torch.cuda.is_available() else 0
     print(f"Model ready in {elapsed:.1f}s | VRAM: {vram_gb:.2f} GB")
@@ -128,7 +125,7 @@ def ocr_page(image: Image.Image, model, processor) -> tuple:
         videos=video_inputs,
         padding=True,
         return_tensors="pt",
-    ).to(model.device)
+    ).to("cuda" if torch.cuda.is_available() else "cpu")
 
     with torch.inference_mode():
         ids = model.generate(


### PR DESCRIPTION
## Problem
After deploying `pipeline.py` to Modal, OCR returns 0 characters in ~1s with no error. The model loads correctly (4.43 GB VRAM) but generates nothing.

## Root cause
`torch.compile(mode="reduce-overhead")` causes Qwen2-VL's generation loop to silently produce 0 tokens on Modal's A10G. No exception is raised — it just returns empty.

## Fix
- Remove `torch.compile` entirely
- Fix `inputs.to(model.device)` → `inputs.to("cuda")` — `model.device` is unreliable with `device_map="auto"`

## Test plan
- [ ] CI passes
- [ ] After merge, OCR returns actual Arabic text (expect 15-30s per page instead of 1s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)