### PR TITLE
fix: correct download button label and replace passlib with bcrypt

### DIFF
--- a/auth-service/app/core/security.py
+++ b/auth-service/app/core/security.py
@@ -1,22 +1,20 @@
 import logging
 from datetime import UTC, datetime, timedelta
 
+import bcrypt
 from jose import JWTError, jwt
-from passlib.context import CryptContext
 
 from app.core.config import settings
 
 logger = logging.getLogger("auth-service.security")
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
 
 
 def create_access_token(subject: str | int) -> str:

--- a/auth-service/pyproject.toml
+++ b/auth-service/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "pydantic-settings>=2.10",
     "python-dotenv>=1.1",
     "python-jose[cryptography]>=3.5",
-    "passlib[bcrypt]>=1.7",
     "bcrypt>=4.0",
     "python-multipart>=0.0.20",
     "psycopg2-binary>=2.9",

--- a/auth-service/uv.lock
+++ b/auth-service/uv.lock
@@ -62,7 +62,6 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "google-auth" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -93,7 +92,6 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.2" },
     { name = "fastapi", specifier = ">=0.116" },
     { name = "google-auth", specifier = ">=2.40" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=6.1" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.11" },
@@ -1226,20 +1224,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-bcrypt = [
-    { name = "bcrypt" },
 ]
 
 [[package]]

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -113,6 +113,7 @@
       "convert": "تحويل",
       "retry": "إعادة المحاولة",
       "downloadPdf": "تنزيل PDF",
+      "downloadDocx": "تنزيل DOCX",
       "delete": "حذف"
     },
     "toasts": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -113,6 +113,7 @@
       "convert": "Convert",
       "retry": "Retry",
       "downloadPdf": "Download PDF",
+      "downloadDocx": "Download DOCX",
       "delete": "Delete"
     },
     "toasts": {

--- a/frontend/src/pages/ConvertPage.jsx
+++ b/frontend/src/pages/ConvertPage.jsx
@@ -524,7 +524,7 @@ function ConvertPage() {
                               className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-500/30 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 transition-colors"
                               style={{ borderRadius: 2 }}>
                               <Download className="w-3 h-3" />
-                              {t("convert.actions.downloadPdf")}
+                              {t("convert.actions.downloadDocx")}
                             </button>
                           )}
                           <button onClick={() => handleDelete(doc.filename)}


### PR DESCRIPTION
## Summary
- **Frontend:** Download button on converted files now correctly shows \"Download DOCX\" instead of \"Download PDF\" (both EN and AR locales)
- **Auth service:** Replaced `passlib` (incompatible with `bcrypt>=4`) with direct `bcrypt` calls — fixes signup/login being broken in both local and prod; existing password hashes are unaffected as the format is identical

## Test plan
- [ ] Sign up with a new account on `https://textara.local` — should succeed
- [ ] Log in with an existing account — should succeed
- [ ] Upload a PDF and convert it — download button should read \"Download DOCX\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)